### PR TITLE
Speedup build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 .vscode
 .pio
 platformio-user.ini
-/lib/AmsConfiguration/include/version.h
+/lib/FirmwareVersion/src/generated_version.h
 /src/web/root
 /src/AmsToMqttBridge.ino.cpp
 /test

--- a/lib/AmsDataStorage/src/AmsDataStorage.cpp
+++ b/lib/AmsDataStorage/src/AmsDataStorage.cpp
@@ -2,7 +2,7 @@
 #include <lwip/apps/sntp.h>
 #include "LittleFS.h"
 #include "AmsStorage.h"
-#include "version.h"
+#include "FirmwareVersion.h"
 
 AmsDataStorage::AmsDataStorage(RemoteDebug* debugger) {
     day.version = 5;
@@ -28,20 +28,20 @@ bool AmsDataStorage::update(AmsData* data) {
         if(debugger->isActive(RemoteDebug::VERBOSE)) debugger->printf_P(PSTR("(AmsDataStorage) Timezone is missing\n"));
         return false;
     }
-    if(now < BUILD_EPOCH) {
-        if(data->getMeterTimestamp() > BUILD_EPOCH) {
+    if(now < FirmwareVersion::BuildEpoch) {
+        if(data->getMeterTimestamp() > FirmwareVersion::BuildEpoch) {
             now = data->getMeterTimestamp();
             if(debugger->isActive(RemoteDebug::DEBUG)) {
                 debugger->printf_P(PSTR("(AmsDataStorage) Using meter timestamp, which is: %lu\n"), (int32_t) now);
             }
-        } else if(data->getPackageTimestamp() > BUILD_EPOCH) {
+        } else if(data->getPackageTimestamp() > FirmwareVersion::BuildEpoch) {
             now = data->getPackageTimestamp();
             if(debugger->isActive(RemoteDebug::DEBUG)) {
                 debugger->printf_P(PSTR("(AmsDataStorage) Using package timestamp, which is: %lu\n"), (int32_t) now);
             }
         }
     }
-    if(now < BUILD_EPOCH) {
+    if(now < FirmwareVersion::BuildEpoch) {
         if(debugger->isActive(RemoteDebug::VERBOSE)) {
             debugger->printf_P(PSTR("(AmsDataStorage) Invalid time: %lu\n"), (int32_t) now);
         }
@@ -551,7 +551,7 @@ bool AmsDataStorage::isHappy() {
 
 bool AmsDataStorage::isDayHappy() {
     time_t now = time(nullptr);
-    if(now < BUILD_EPOCH) return false;
+    if(now < FirmwareVersion::BuildEpoch) return false;
     tmElements_t tm, last;
 
     if(now < day.lastMeterReadTime) {
@@ -579,7 +579,7 @@ bool AmsDataStorage::isMonthHappy() {
     }
 
     time_t now = time(nullptr);
-    if(now < BUILD_EPOCH) return false;
+    if(now < FirmwareVersion::BuildEpoch) return false;
     tmElements_t tm, last;
     
     if(now < month.lastMeterReadTime) {

--- a/lib/EnergyAccounting/src/EnergyAccounting.cpp
+++ b/lib/EnergyAccounting/src/EnergyAccounting.cpp
@@ -1,7 +1,7 @@
 #include "EnergyAccounting.h"
 #include "LittleFS.h"
 #include "AmsStorage.h"
-#include "version.h"
+#include "FirmwareVersion.h"
 
 EnergyAccounting::EnergyAccounting(RemoteDebug* debugger) {
     data.version = 1;
@@ -33,7 +33,7 @@ bool EnergyAccounting::isInitialized() {
 bool EnergyAccounting::update(AmsData* amsData) {
     if(config == NULL) return false;
     time_t now = time(nullptr);
-    if(now < BUILD_EPOCH) return false;
+    if(now < FirmwareVersion::BuildEpoch) return false;
     if(tz == NULL) {
         if(debugger->isActive(RemoteDebug::VERBOSE)) debugger->printf_P(PSTR("(EnergyAccounting) Timezone is missing\n"));
         return false;
@@ -188,7 +188,7 @@ float EnergyAccounting::getUseThisHour() {
 float EnergyAccounting::getUseToday() {
     float ret = 0.0;
     time_t now = time(nullptr);
-    if(now < BUILD_EPOCH) return 0.0;
+    if(now < FirmwareVersion::BuildEpoch) return 0.0;
     if(tz == NULL) return 0.0;
     tmElements_t utc, local;
     breakTime(tz->toLocal(now), local);
@@ -201,7 +201,7 @@ float EnergyAccounting::getUseToday() {
 
 float EnergyAccounting::getUseThisMonth() {
     time_t now = time(nullptr);
-    if(now < BUILD_EPOCH) return 0.0;
+    if(now < FirmwareVersion::BuildEpoch) return 0.0;
     float ret = 0;
     for(uint8_t i = 0; i < currentDay; i++) {
         ret += ds->getDayImport(i) / 1000.0;
@@ -216,7 +216,7 @@ float EnergyAccounting::getProducedThisHour() {
 float EnergyAccounting::getProducedToday() {
     float ret = 0.0;
     time_t now = time(nullptr);
-    if(now < BUILD_EPOCH) return 0.0;
+    if(now < FirmwareVersion::BuildEpoch) return 0.0;
     tmElements_t utc, local;
     breakTime(tz->toLocal(now), local);
     for(uint8_t i = 0; i < currentHour; i++) {
@@ -228,7 +228,7 @@ float EnergyAccounting::getProducedToday() {
 
 float EnergyAccounting::getProducedThisMonth() {
     time_t now = time(nullptr);
-    if(now < BUILD_EPOCH) return 0.0;
+    if(now < FirmwareVersion::BuildEpoch) return 0.0;
     float ret = 0;
     for(uint8_t i = 0; i < currentDay; i++) {
         ret += ds->getDayExport(i) / 1000.0;

--- a/lib/EntsoePriceApi/src/EntsoeApi.cpp
+++ b/lib/EntsoePriceApi/src/EntsoeApi.cpp
@@ -3,7 +3,7 @@
 #include "Uptime.h"
 #include "TimeLib.h"
 #include "DnbCurrParser.h"
-#include "version.h"
+#include "FirmwareVersion.h"
 
 #include "GcmParser.h"
 
@@ -37,7 +37,7 @@ void EntsoeApi::setup(EntsoeConfig& config) {
     http.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
     http.setReuse(false);
     http.setTimeout(60000);
-    http.setUserAgent("ams2mqtt/" + String(VERSION));
+    http.setUserAgent("ams2mqtt/" + String(FirmwareVersion::VersionString));
     http.useHTTP10(true);
 
     #if defined(AMS2MQTT_PRICE_KEY)
@@ -135,7 +135,7 @@ bool EntsoeApi::loop() {
     if(now < 10000) return false; // Grace period
 
     time_t t = time(nullptr);
-    if(t < BUILD_EPOCH) return false;
+    if(t < FirmwareVersion::BuildEpoch) return false;
 
     #ifndef AMS2MQTT_PRICE_KEY
     if(strlen(getToken()) == 0) {

--- a/lib/FirmwareVersion/include/FirmwareVersion.h
+++ b/lib/FirmwareVersion/include/FirmwareVersion.h
@@ -1,0 +1,12 @@
+#ifndef _FIRMWARE_VERSION_h
+#define _FIRMWARE_VERSION_h
+
+
+class FirmwareVersion {
+public:
+	static long BuildEpoch;
+	static const char* VersionString;
+};
+
+#endif
+

--- a/lib/FirmwareVersion/src/FirmwareVersion.cpp
+++ b/lib/FirmwareVersion/src/FirmwareVersion.cpp
@@ -1,0 +1,5 @@
+#include "FirmwareVersion.h"
+#include "generated_version.h"
+
+long FirmwareVersion::BuildEpoch = BUILD_EPOCH;
+const char* FirmwareVersion::VersionString = VERSION_STRING;

--- a/lib/HomeAssistantMqttHandler/include/HomeAssistantStatic.h
+++ b/lib/HomeAssistantMqttHandler/include/HomeAssistantStatic.h
@@ -3,7 +3,7 @@
 
 #include "Arduino.h"
 
-typedef struct HomeAssistantSensor {
+struct HomeAssistantSensor {
     const char* name;
     const char* topic;
     const char* path;

--- a/lib/HomeAssistantMqttHandler/src/HomeAssistantMqttHandler.cpp
+++ b/lib/HomeAssistantMqttHandler/src/HomeAssistantMqttHandler.cpp
@@ -1,7 +1,7 @@
 #include "HomeAssistantMqttHandler.h"
 #include "hexutils.h"
 #include "Uptime.h"
-#include "version.h"
+#include "FirmwareVersion.h"
 #include "json/ha1_json.h"
 #include "json/ha2_json.h"
 #include "json/ha3_json.h"
@@ -329,7 +329,7 @@ bool HomeAssistantMqttHandler::publishSystem(HwTools* hw, EntsoeApi* eapi, Energ
         hw->getVcc(),
         hw->getWifiRssi(),
         hw->getTemperature(),
-        VERSION
+        FirmwareVersion::VersionString
     );
     bool ret = mqtt->publish(topic + "/state", json);
     loop();
@@ -353,7 +353,7 @@ void HomeAssistantMqttHandler::publishSensor(const HomeAssistantSensor& sensor) 
         deviceUid.c_str(),
         deviceName.c_str(),
         deviceModel.c_str(),
-        VERSION,
+        FirmwareVersion::VersionString,
         manufacturer.c_str(),
         deviceUrl.c_str(),
         strlen_P(sensor.devcl) > 0 ? ",\"dev_cla\":\"" : "",

--- a/lib/JsonMqttHandler/src/JsonMqttHandler.cpp
+++ b/lib/JsonMqttHandler/src/JsonMqttHandler.cpp
@@ -1,5 +1,5 @@
 #include "JsonMqttHandler.h"
-#include "version.h"
+#include "FirmwareVersion.h"
 #include "hexutils.h"
 #include "Uptime.h"
 #include "json/json1_json.h"
@@ -341,7 +341,7 @@ bool JsonMqttHandler::publishSystem(HwTools* hw, EntsoeApi* eapi, EnergyAccounti
         hw->getVcc(),
         hw->getWifiRssi(),
         hw->getTemperature(),
-        VERSION
+        FirmwareVersion::VersionString
     );
     bool ret = mqtt->publish(topic, json);
     loop();

--- a/platformio.ini
+++ b/platformio.ini
@@ -2,7 +2,7 @@
 extra_configs = platformio-user.ini
 
 [common]
-lib_deps = EEPROM, LittleFS, DNSServer, https://github.com/256dpi/arduino-mqtt.git, OneWireNg@0.10.0, DallasTemperature@3.9.1, EspSoftwareSerial@6.14.1, https://github.com/gskjold/RemoteDebug.git, Time@1.6.1, Timezone@1.2.4, AmsConfiguration, AmsData, AmsDataStorage, HwTools, Uptime, AmsDecoder, EntsoePriceApi, EnergyAccounting, RawMqttHandler, JsonMqttHandler, DomoticzMqttHandler, HomeAssistantMqttHandler, SvelteUi
+lib_deps = EEPROM, LittleFS, DNSServer, https://github.com/256dpi/arduino-mqtt.git, OneWireNg@0.10.0, DallasTemperature@3.9.1, EspSoftwareSerial@6.14.1, https://github.com/gskjold/RemoteDebug.git, Time@1.6.1, Timezone@1.2.4, FirmwareVersion, AmsConfiguration, AmsData, AmsDataStorage, HwTools, Uptime, AmsDecoder, EntsoePriceApi, EnergyAccounting, RawMqttHandler, JsonMqttHandler, DomoticzMqttHandler, HomeAssistantMqttHandler, SvelteUi
 lib_ignore = OneWire
 extra_scripts =
     pre:scripts/addversion.py

--- a/scripts/addversion.py
+++ b/scripts/addversion.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 from time import time
 
-FILENAME_VERSION_H = 'lib/AmsConfiguration/include/version.h'
+FILENAME_VERSION_H = 'lib/FirmwareVersion/src/generated_version.h'
 version = os.environ.get('GITHUB_TAG')
 if version == None:
     try:
@@ -15,9 +15,7 @@ if version == None:
       version = "SNAPSHOT"
 
 hf = """
-#ifndef VERSION
-  #define VERSION "{}"
-#endif
+#define VERSION_STRING "{}"
 #define BUILD_EPOCH {}
 """.format(version, round(time()))
 with open(FILENAME_VERSION_H, 'w+') as f:

--- a/src/AmsToMqttBridge.cpp
+++ b/src/AmsToMqttBridge.cpp
@@ -23,6 +23,8 @@
  * to Norwegian meters, but may also support data from electricity providers in other countries. 
  */
 
+#include <Arduino.h>
+
 #if defined(ESP8266)
 ADC_MODE(ADC_VCC);
 #endif
@@ -131,6 +133,29 @@ GCMParser *gcmParser = NULL;
 LLCParser *llcParser = NULL;
 DLMSParser *dlmsParser = NULL;
 DSMRParser *dsmrParser = NULL;
+
+
+void configFileParse();
+void swapWifiMode();
+void WiFi_connect();
+void WiFi_post_connect();
+void MQTT_connect();
+void handleNtpChange();
+void handleDataSuccess(AmsData* data);
+void handleTemperature(unsigned long now);
+void handleSystem(unsigned long now);
+void handleAutodetect(unsigned long now);
+void handleButton(unsigned long now);
+void handlePriceApi(unsigned long now);
+void handleEnergyAccountingChanged();
+bool readHanPort();
+void setupHanPort(GpioConfig& gpioConfig, uint32_t baud, uint8_t parityOrdinal, bool invert);
+void rxerr(int err);
+int16_t unwrapData(uint8_t *buf, DataParserContext &context);
+void errorBlink();
+void printHanReadError(int pos);
+void debugPrint(byte *buffer, int start, int length);
+
 
 void setup() {
 	Serial.begin(115200);

--- a/src/AmsToMqttBridge.ino
+++ b/src/AmsToMqttBridge.ino
@@ -36,8 +36,7 @@ ADC_MODE(ADC_VCC);
 #include <driver/uart.h>
 #endif
 
-#include "version.h"
-
+#include "FirmwareVersion.h"
 #include "AmsToMqttBridge.h"
 #include "AmsStorage.h"
 #include "AmsDataStorage.h"
@@ -309,7 +308,7 @@ void setup() {
 					}
 					flashed = Update.end(true);
 				}
-				config.setUpgradeInformation(flashed ? 2 : 0, 0xFF, VERSION, "");
+				config.setUpgradeInformation(flashed ? 2 : 0, 0xFF, FirmwareVersion::VersionString, "");
 				firmwareFile.close();
 			} else {
 				debugW_P(PSTR("AP button pressed, skipping firmware update and deleting firmware file."));
@@ -1126,15 +1125,15 @@ void handleDataSuccess(AmsData* data) {
 	}
 
 	time_t now = time(nullptr);
-	if(now < BUILD_EPOCH && data->getListType() >= 3) {
-		if(data->getMeterTimestamp() > BUILD_EPOCH) {
+	if(now < FirmwareVersion::BuildEpoch && data->getListType() >= 3) {
+		if(data->getMeterTimestamp() > FirmwareVersion::BuildEpoch) {
 			debugI_P(PSTR("Using timestamp from meter"));
 			now = data->getMeterTimestamp();
-		} else if(data->getPackageTimestamp() > BUILD_EPOCH) {
+		} else if(data->getPackageTimestamp() > FirmwareVersion::BuildEpoch) {
 			debugI_P(PSTR("Using timestamp from meter (DLMS)"));
 			now = data->getPackageTimestamp();
 		}
-		if(now > BUILD_EPOCH) {
+		if(now > FirmwareVersion::BuildEpoch) {
 			timeval tv { now, 0};
 			settimeofday(&tv, nullptr);
 		}
@@ -1143,7 +1142,7 @@ void handleDataSuccess(AmsData* data) {
 	meterState.apply(*data);
 
 	bool saveData = false;
-	if(!ds.isHappy() && now > BUILD_EPOCH) {
+	if(!ds.isHappy() && now > FirmwareVersion::BuildEpoch) {
 		debugD_P(PSTR("Its time to update data storage"));
 		tmElements_t tm;
 		breakTime(now, tm);
@@ -1619,7 +1618,7 @@ void MQTT_connect() {
 
 	time_t epoch = time(nullptr);
 	if(mqttConfig.ssl) {
-		if(epoch < BUILD_EPOCH) {
+		if(epoch < FirmwareVersion::BuildEpoch) {
 			debugI_P(PSTR("NTP not ready for MQTT SSL"));
 			return;
 		}

--- a/src/version.h
+++ b/src/version.h
@@ -1,5 +1,0 @@
-
-#ifndef VERSION
-  #define VERSION "538de5e"
-#endif
-#define BUILD_EPOCH 1668532199


### PR DESCRIPTION
### [Move version constants into its own compile-unit](https://github.com/UtilitechAS/amsreader-firmware/commit/66a10e14cd7388d2f1b2d0dadd0314d6cc8031c2)
Speeds up the build by moving those constants into a separate compile-unit.
Currently, since the version header is auto regenerated on each build,
all modules that include it, also have to be recompiled every time.
By putting it into a compile-unit, only this tiny lib is recompiled and then linked with rest.

### [Convert Arduino sketch to C++](https://github.com/UtilitechAS/amsreader-firmware/commit/e0171e8b06042b6ea66efb31eda8ea2db3de6b3e) (fixes https://github.com/UtilitechAS/amsreader-firmware/issues/438)
Also speeds up the build: As a INO sketch, `AmsToMqttBridge.ino` is converted into `AmsToMqttBridge.ino.cpp` on every build and recompiled.


Last commit fixes this warning:
`warning: 'typedef' was ignored in this declaration`