### PR TITLE
Pre-compress index JS/CSS with gzip

### DIFF
--- a/lib/SvelteUi/include/AmsWebHeaders.h
+++ b/lib/SvelteUi/include/AmsWebHeaders.h
@@ -1,10 +1,12 @@
 static const char HEADER_CACHE_CONTROL[] PROGMEM = "Cache-Control";
+static const char HEADER_CONTENT_ENCODING[] PROGMEM = "Content-Encoding";
 static const char HEADER_PRAGMA[] PROGMEM = "Pragma";
 static const char HEADER_EXPIRES[] PROGMEM = "Expires";
 static const char HEADER_AUTHENTICATE[] PROGMEM = "WWW-Authenticate";
 static const char HEADER_LOCATION[] PROGMEM = "Location";
 
 static const char CACHE_CONTROL_NO_CACHE[] PROGMEM = "no-cache, no-store, must-revalidate";
+static const char CONTENT_ENCODING_GZIP[] PROGMEM = "gzip";
 static const char CACHE_1HR[] PROGMEM = "public, max-age=3600";
 static const char CACHE_1MO[] PROGMEM = "public, max-age=2592000";
 static const char PRAGMA_NO_CACHE[] PROGMEM = "no-cache";

--- a/lib/SvelteUi/src/AmsWebServer.cpp
+++ b/lib/SvelteUi/src/AmsWebServer.cpp
@@ -765,8 +765,8 @@ void AmsWebServer::indexCss() {
 		return;
 
 	server.sendHeader(HEADER_CACHE_CONTROL, CACHE_1MO);
-	server.setContentLength(INDEX_CSS_LEN);
-	server.send_P(200, MIME_CSS, INDEX_CSS);
+	server.sendHeader(HEADER_CONTENT_ENCODING, CONTENT_ENCODING_GZIP);
+	server.send_P(200, MIME_CSS, INDEX_CSS, INDEX_CSS_LEN);
 }
 
 void AmsWebServer::indexJs() {
@@ -776,7 +776,8 @@ void AmsWebServer::indexJs() {
 		return;
 
 	server.sendHeader(HEADER_CACHE_CONTROL, CACHE_1MO);
-	server.send_P(200, MIME_JS, INDEX_JS);
+	server.sendHeader(HEADER_CONTENT_ENCODING, CONTENT_ENCODING_GZIP);
+	server.send_P(200, MIME_JS, INDEX_JS, INDEX_JS_LEN);
 }
 
 void AmsWebServer::configurationJson() {


### PR DESCRIPTION
Compressing the main script and stylesheet saves ~140kB in flash memory and shortens WiFi transmission time during first load.

Edit: compression using brotli would save another 10-20kB, but has slightly less browser support, and browsers don't send an brotli accept-encoding header when not on https: https://stackoverflow.com/questions/43862412/why-is-brotli-not-supported-on-http