### PR TITLE
Add uptime to system sensors for home assistant

### DIFF
--- a/lib/HomeAssistantMqttHandler/include/HomeAssistantStatic.h
+++ b/lib/HomeAssistantMqttHandler/include/HomeAssistantStatic.h
@@ -107,10 +107,11 @@ const HomeAssistantSensor PriceSensors[PriceSensorCount] PROGMEM = {
 
 const HomeAssistantSensor PriceSensor PROGMEM = {"Price in %02d %s", "/prices", "prices['%d']", 4000, "", "monetary", ""};
 
-const uint8_t SystemSensorCount PROGMEM = 2;
+const uint8_t SystemSensorCount PROGMEM = 3;
 const HomeAssistantSensor SystemSensors[SystemSensorCount] PROGMEM = {
     {"Status",                     "/state",   "rssi",               180, "dBm",  "signal_strength", "measurement"},
-    {"Supply volt",                "/state",   "vcc",                180, "V",    "voltage",         "measurement"}
+    {"Supply volt",                "/state",   "vcc",                180, "V",    "voltage",         "measurement"},
+    {"Uptime",                     "/state",   "up",                 180, "s",    "uptime",          "measurement"}
 };
 
 const HomeAssistantSensor TemperatureSensor PROGMEM = {"Temperature sensor %s", "/temperatures", "temperatures['%s']", 900, "°C", "temperature", "measurement"};


### PR DESCRIPTION
Uptime is already part of the MQTT messages, but not among the sensors indicated to home assistant. Useful for troubleshooting purposes.

Please test this change, I don't have my development environment with me and the code is just hand edited.