### PR TITLE
Use correct home assistant device class for uptime

### DIFF
--- a/lib/HomeAssistantMqttHandler/include/HomeAssistantStatic.h
+++ b/lib/HomeAssistantMqttHandler/include/HomeAssistantStatic.h
@@ -117,7 +117,7 @@ const uint8_t SystemSensorCount PROGMEM = 3;
 const HomeAssistantSensor SystemSensors[SystemSensorCount] PROGMEM = {
     {"Status",                     "/state",   "rssi",               180, "dBm",  "signal_strength", "measurement"},
     {"Supply volt",                "/state",   "vcc",                180, "V",    "voltage",         "measurement"},
-    {"Uptime",                     "/state",   "up",                 180, "s",    "uptime",          "measurement"}
+    {"Uptime",                     "/state",   "up",                 180, "s",    "duration",        "measurement"}
 };
 
 const HomeAssistantSensor TemperatureSensor PROGMEM = {"Temperature sensor %s", "/temperatures", "temperatures['%s']", 900, "°C", "temperature", "measurement"};


### PR DESCRIPTION
I've chosen a non-existent device class beforehand, my bad.