### PR TITLE
Detect iskra based on system title

### DIFF
--- a/src/IEC6205675.cpp
+++ b/src/IEC6205675.cpp
@@ -267,6 +267,16 @@ IEC6205675::IEC6205675(const char* d, uint8_t useMeterType, MeterConfig* meterCo
             activeImportPower = ntohl(data->dlu.data);
             lastUpdateMillis = millis64();
         }
+
+        if(meterType == AmsTypeUnknown) {
+            if(memcmp(ctx.system_title, "ISK", 3) == 0) {
+                meterType = AmsTypeIskra;
+                meterId = String((const uint8_t*)ctx.system_title, 8);
+                lastUpdateMillis = millis64();
+                listType = 3;
+            }
+        }
+
     } else {
         listType = 1;
         activeImportPower = val;


### PR DESCRIPTION
For Iskra AM550 deployed in Austria, operator "Wiener Netze".

Operator docs: https://www.wienernetze.at/kundenschnittstelle2

Serial settings: 9600 8N1

[x] Meter is encrypted
