### PR TITLE
Add devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "amsreader-devcontainer",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/base:jammy",
+	"features": {
+		"ghcr.io/devcontainers/features/node:1": {
+			"version": "16",
+			"pnpmVersion": "none",
+			"nvmVersion": "latest"
+		},
+		"ghcr.io/devcontainers/features/python:1": {
+			"version": "3.9"
+		}
+	},
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": ".devcontainer/postCreateCommand.sh",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"platformio.platformio-ide",
+				"ms-vscode.cpptools",
+				"svelte.svelte-vscode"
+			]
+		}
+	}
+}

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+# Upgrade pip
+python -m pip install --upgrade pip
+
+# Install Python packages
+pip install -U platformio css_html_js_minify
+
+# Navigate to the Svelte app directory
+cd lib/SvelteUi/app
+
+# Install npm dependencies and build the app
+npm ci
+npm run build
+
+# Return to the previous directory
+cd -

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf


### PR DESCRIPTION
Simple devcontainer config to easily setup dev environment & dependencies.
Versions are based on what's used in github actions. You might want to update nodejs as v16 is end of life.

Another thing, would you consider adding `lib/SvelteUi/app/dist` to `.gitignore`? The files get created when building anyways and just get in the way of version control.
