### PR TITLE
Fixed ESP8266 data loss after upgrade (#926)

### DIFF
--- a/lib/AmsFirmwareUpdater/include/AmsFirmwareUpdater.h
+++ b/lib/AmsFirmwareUpdater/include/AmsFirmwareUpdater.h
@@ -17,6 +17,9 @@
     #define AMS_PARTITION_MIN_SPIFFS_SIZE 0x20000
 #elif defined(ESP8266)
 	#include <ESP8266HTTPClient.h>
+
+    #define AMS_FLASH_SKETCH_SIZE 0xFEFF0
+    #define AMS_FLASH_OTA_START AMS_FLASH_OTA_SIZE
 #endif
 
 #if defined(AMS_REMOTE_DEBUG)

--- a/lib/SvelteUi/src/AmsWebServer.cpp
+++ b/lib/SvelteUi/src/AmsWebServer.cpp
@@ -89,9 +89,9 @@ void AmsWebServer::setup(AmsConfiguration* config, GpioConfig* gpioConfig, AmsDa
 			context = "";
 		} else {
 			#if defined(AMS_REMOTE_DEBUG)
-if (debugger->isActive(RemoteDebug::INFO))
-#endif
-debugger->printf_P(PSTR("Using context path: '%s'\n"), context.c_str());
+			if (debugger->isActive(RemoteDebug::INFO))
+			#endif
+			debugger->printf_P(PSTR("Using context path: '%s'\n"), context.c_str());
 		}
 	}
 
@@ -814,7 +814,6 @@ void AmsWebServer::indexHtml() {
 }
 
 void AmsWebServer::indexCss() {
-
 	if(!checkSecurity(2))
 		return;
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,7 +22,7 @@ build_flags =
 lib_deps = WiFi, Ethernet, ESPmDNS, WiFiClientSecure, HTTPClient, FS, WebServer, ESP32 Async UDP, ESP32SSDP, mulmer89/ESPRandom@1.5.0, ${common.lib_deps}, CloudConnector, SvelteUi
 
 [env:esp8266]
-platform = espressif8266@4.2.0
+platform = espressif8266@4.2.1
 framework = arduino
 board = esp12e
 board_build.ldscript = eagle.flash.4m2m.ld


### PR DESCRIPTION
Fixes #926 where historical data and price modifiers are lost when upgrading ESP8266 between any 2.4.x version