### PR TITLE
Fixed MQTT reconnect when SSL is enabled (#918)

### DIFF
--- a/lib/AmsMqttHandler/src/AmsMqttHandler.cpp
+++ b/lib/AmsMqttHandler/src/AmsMqttHandler.cpp
@@ -33,15 +33,18 @@ bool AmsMqttHandler::connect() {
 		if(epoch < FirmwareVersion::BuildEpoch) {
 			return false;
 		}
+		
+		bool applySslConfiguration = mqttConfigChanged;
 		if(mqttSecureClient == NULL) {
 			mqttSecureClient = new WiFiClientSecure();
 			#if defined(ESP8266)
 				mqttSecureClient->setBufferSizes(512, 512);
 				return false;
 			#endif
+			applySslConfiguration = true;
 		}
 
-		if(mqttConfigChanged) {
+		if(applySslConfiguration) {
 			if(caVerification && LittleFS.begin()) {
 				File file;
 


### PR DESCRIPTION
If MQTT/SSL is enabled and the broker restarts, the MQTT connection does not recover. The issue is that SSL client is deleted on disconnect(), and then does not properly reconfigure the new one when trying to reconnect.