### PR TITLE
Fixed reboot loop during upgrade (#935)

### DIFF
--- a/lib/AmsFirmwareUpdater/src/AmsFirmwareUpdater.cpp
+++ b/lib/AmsFirmwareUpdater/src/AmsFirmwareUpdater.cpp
@@ -97,6 +97,11 @@ float AmsFirmwareUpdater::getProgress() {
 }
 
 void AmsFirmwareUpdater::loop() {
+    if(millis() < 30000) {
+        // Wait 30 seconds before starting upgrade. This allows the device to deal with other tasks first
+        // It will also allow BUS powered devices to reach a stable voltage so that hw->isVoltageOptimal will behave properly
+        return; 
+    }
     if(strlen(updateStatus.toVersion) > 0 && updateStatus.errorCode == AMS_UPDATE_ERR_OK) {
         if(!hw->isVoltageOptimal(0.1)) {
             writeUpdateStatus();

--- a/lib/HwTools/include/HwTools.h
+++ b/lib/HwTools/include/HwTools.h
@@ -67,7 +67,7 @@ private:
     bool ledInvert, rgbInvert;
     uint8_t vccPin, vccGnd_r, vccVcc_r;
     float vccOffset, vccMultiplier;
-    float maxVcc = 3.2; // Best to have this close to max as a start, in case Pow-U reboots and starts off with a low voltage, we dont want that to be perceived as max
+    float maxVcc = 3.25; // Best to have this close to max as a start, in case Pow-U reboots and starts off with a low voltage, we dont want that to be perceived as max
 
     uint16_t analogRange = 1024;
     AdcConfig voltAdc, tempAdc;


### PR DESCRIPTION
Applies for BUS powered devices.
In some cases, if the device reboots during an upgrade, it will enter a state of reboot loops and never recover unless USB power is supplied.

To avoid this, the device will now wait 30s before continuing the upgrade. This allows for other tasks to complete first. It also allows the device to charge the capacitor and reach a stable voltage before upgrade is resumed.

The initial max vcc detected has also been raised from 3.20V to 3.25V