### PR TITLE
Fixed price modifier date inclusion

### DIFF
--- a/lib/PriceService/include/PriceService.h
+++ b/lib/PriceService/include/PriceService.h
@@ -129,5 +129,6 @@ private:
     PricesContainer* fetchPrices(time_t);
     bool retrieve(const char* url, Stream* doc);
     float getCurrencyMultiplier(const char* from, const char* to, time_t t);
+    bool timeIsInPeriod(tmElements_t tm, PriceConfig pc);
 };
 #endif

--- a/lib/PriceService/src/PriceService.cpp
+++ b/lib/PriceService/src/PriceService.cpp
@@ -111,8 +111,6 @@ float PriceService::getValueForHour(uint8_t direction, time_t ts, int8_t hour) {
 
     tmElements_t tm;
     breakTime(tz->toLocal(ts + (hour * SECS_PER_HOUR)), tm);
-    uint8_t day = 0x01 << ((tm.Wday+5)%7);
-    uint32_t hrs = 0x01 << tm.Hour;
 
     for (uint8_t i = 0; i < priceConfig.size(); i++) {
         PriceConfig pc = priceConfig.at(i);
@@ -137,8 +135,6 @@ float PriceService::getValueForHour(uint8_t direction, time_t ts, int8_t hour) {
 float PriceService::getEnergyPriceForHour(uint8_t direction, time_t ts, int8_t hour) {
     tmElements_t tm;
     breakTime(tz->toLocal(ts + (hour * SECS_PER_HOUR)), tm);
-    uint8_t day = 0x01 << ((tm.Wday+5)%7);
-    uint32_t hrs = 0x01 << tm.Hour;
 
     float value = PRICE_NO_VALUE;
     for (uint8_t i = 0; i < priceConfig.size(); i++) {
@@ -627,8 +623,8 @@ bool PriceService::load() {
 
 
 bool PriceService::timeIsInPeriod(tmElements_t tm, PriceConfig pc) {
-    int day = 0x01 << ((tm.Wday+5)%7);
-    int hrs = 0x01 << tm.Hour;
+    uint8_t day = 0x01 << ((tm.Wday+5)%7);
+    uint32_t hrs = 0x01 << tm.Hour;
 
     if((pc.days & day) != day) return false;
     if((pc.hours & hrs) != hrs) return false;
@@ -637,7 +633,7 @@ bool PriceService::timeIsInPeriod(tmElements_t tm, PriceConfig pc) {
     tms.Year = tm.Year;
     tms.Month = pc.start_month;
     tms.Day = pc.start_dayofmonth;
-    tms.Hour = (pc.hours & hrs) == hrs ? tm.Hour : 0;
+    tms.Hour = 0;
     tms.Minute = 0;
     tms.Second = 0;
 
@@ -645,9 +641,9 @@ bool PriceService::timeIsInPeriod(tmElements_t tm, PriceConfig pc) {
     tme.Year = tm.Year;
     tme.Month = pc.end_month;
     tme.Day = pc.end_dayofmonth;
-    tme.Hour = (pc.hours & hrs) == hrs ? tm.Hour : 0;
-    tme.Minute = 0;
-    tme.Second = 0;
+    tme.Hour = 23;
+    tme.Minute = 59;
+    tme.Second = 59;
     if(makeTime(tms) > makeTime(tme)) {
         if(makeTime(tm) <= makeTime(tme)) {
             tms.Year--;

--- a/lib/PriceService/src/PriceService.cpp
+++ b/lib/PriceService/src/PriceService.cpp
@@ -118,9 +118,18 @@ float PriceService::getValueForHour(uint8_t direction, time_t ts, int8_t hour) {
         PriceConfig pc = priceConfig.at(i);
         if(pc.type == PRICE_TYPE_FIXED) continue;
         uint8_t start_month = pc.start_month == 0 || pc.start_month > 12 ? 1 : pc.start_month;
-        uint8_t start_dayofmonth = pc.start_dayofmonth == 0 || pc.start_dayofmonth > 31 ? 1 : pc.start_dayofmonth;
+        uint8_t start_dayofmonth = pc.start_month != tm.Month ? 1 : pc.start_dayofmonth;
         uint8_t end_month = pc.end_month == 0 || pc.end_month > 12 ? 12 : pc.end_month;
-        uint8_t end_dayofmonth = pc.end_dayofmonth == 0 || pc.end_dayofmonth > 31 ? 31 : pc.end_dayofmonth;
+        uint8_t end_dayofmonth = pc.end_month != tm.Month ? 31 : pc.end_dayofmonth;
+        if(pc.end_month < pc.start_month) {
+            if(tm.Month > pc.end_month) {
+                end_month = 12;
+                end_dayofmonth = 31;
+            } else {
+                start_month = 1;
+                start_dayofmonth = 1;
+            }
+        }
 
         if((pc.direction & direction) == direction && (pc.days & day) == day && (pc.hours & hrs) == hrs && tm.Month >= start_month && tm.Day >= start_dayofmonth && tm.Month <= end_month && tm.Day <= end_dayofmonth) {
             switch(pc.type) {


### PR DESCRIPTION
For price modifiers, there have been some issues where the modifiers have not been applied. These are as follows:
- When end date is before the start date (or rather, the end date is actually next year)
- When the end day is not 30/31