### PR TITLE
Added per phase power for L&G

### DIFF
--- a/lib/MeterCommunicators/src/LNG.cpp
+++ b/lib/MeterCommunicators/src/LNG.cpp
@@ -54,12 +54,15 @@ LNG::LNG(AmsData& meterState, const char* payload, uint8_t useMeterType, MeterCo
                             break;
                         case 21:
                             l1activeImportPower = getNumber(item);
+                            listType = listType >= 4 ? listType : 4;
                             break;
                         case 41:
                             l2activeImportPower = getNumber(item);
+                            listType = listType >= 4 ? listType : 4;
                             break;
                         case 61:
                             l3activeImportPower = getNumber(item);
+                            listType = listType >= 4 ? listType : 4;
                             break;
                         case 31:
                             l1current = getNumber(item) / 100.0;


### PR DESCRIPTION
For Austrian L&G meters, we have now added support for parsing OBIS 21.7.0, 41.7.0 and 61.7.0 which is L1, L2 and L3 phase power