### PR TITLE
Trim leading and trailing white space

### DIFF
--- a/lib/AmsConfiguration/include/hexutils.h
+++ b/lib/AmsConfiguration/include/hexutils.h
@@ -13,7 +13,7 @@
 String toHex(uint8_t* in);
 String toHex(uint8_t* in, uint16_t size);
 void fromHex(uint8_t *out, String in, uint16_t size);
-bool stripNonAscii(uint8_t* in, uint16_t size, bool extended = false);
+bool stripNonAscii(uint8_t* in, uint16_t size, bool extended = false, bool trim = true);
 void debugPrint(uint8_t *buffer, uint16_t start, uint16_t length, Print* debugger);
 
 #endif

--- a/lib/AmsConfiguration/src/AmsConfiguration.cpp
+++ b/lib/AmsConfiguration/src/AmsConfiguration.cpp
@@ -91,7 +91,7 @@ bool AmsConfiguration::setNetworkConfig(NetworkConfig& config) {
 	}
 	
 	stripNonAscii((uint8_t*) config.ssid, 32, true);
-	stripNonAscii((uint8_t*) config.psk, 64, true);
+	stripNonAscii((uint8_t*) config.psk, 64, true, false);
 	stripNonAscii((uint8_t*) config.ip, 16);
 	stripNonAscii((uint8_t*) config.gateway, 16);
 	stripNonAscii((uint8_t*) config.subnet, 16);
@@ -186,7 +186,7 @@ bool AmsConfiguration::setMqttConfig(MqttConfig& config) {
 	stripNonAscii((uint8_t*) config.publishTopic, 64);
 	stripNonAscii((uint8_t*) config.subscribeTopic, 64);
 	stripNonAscii((uint8_t*) config.username, 128, true);
-	stripNonAscii((uint8_t*) config.password, 256, true);
+	stripNonAscii((uint8_t*) config.password, 256, true, false);
 	if(config.timeout < 500) config.timeout = 1000;
 	if(config.timeout > 10000) config.timeout = 1000;
 	if(config.keepalive < 5) config.keepalive = 60;
@@ -252,7 +252,7 @@ bool AmsConfiguration::setWebConfig(WebConfig& config) {
 	}
 
 	stripNonAscii((uint8_t*) config.username, 37);
-	stripNonAscii((uint8_t*) config.password, 37);
+	stripNonAscii((uint8_t*) config.password, 37, false, false);
 	stripNonAscii((uint8_t*) config.context, 37);
 
 	EEPROM.begin(EEPROM_SIZE);

--- a/lib/AmsConfiguration/src/hexutils.cpp
+++ b/lib/AmsConfiguration/src/hexutils.cpp
@@ -28,7 +28,7 @@ void fromHex(uint8_t *out, String in, uint16_t size) {
 	}
 }
 
-bool stripNonAscii(uint8_t* in, uint16_t size, bool extended) {
+bool stripNonAscii(uint8_t* in, uint16_t size, bool extended, bool trim) {
 	bool ret = false;
 	for(uint16_t i = 0; i < size; i++) {
 		if(in[i] == 0) { // Clear the rest with null-terminator
@@ -41,6 +41,22 @@ bool stripNonAscii(uint8_t* in, uint16_t size, bool extended) {
 		} else if(!extended && (in[i] < 32 || in[i] > 126)) {
 			memset(in+i, ' ', 1);
 			ret = true;
+		}
+	}
+	if(trim) {
+		// Strip leading spaces
+		while(in[0] == ' ') {
+			for(uint16_t i = 0; i < size; i++) {
+				in[i] = in[i+1];
+			}
+		}
+		// Strip trailing spaces
+		for(int i = size-1; i > 0; i--) {
+			if(in[i] == ' ' || in[i] == 0) {
+				memset(in+i, 0, 1);
+			} else {
+				break;
+			}
 		}
 	}
 	memset(in+size-1, 0, 1); // Make sure the last character is null-terminator


### PR DESCRIPTION
On most input fields it makes no sense keeping leading and trailing white space. Still allowing on passwords, although maybe up for discussion?