### PR TITLE
Fixed Kamstrup timestamp parsing

### DIFF
--- a/lib/AmsDecoder/src/Cosem.cpp
+++ b/lib/AmsDecoder/src/Cosem.cpp
@@ -19,8 +19,6 @@ time_t decodeCosemDateTime(CosemDateTime timestamp) {
     tm.Minute = timestamp.minute;
     tm.Second = timestamp.second;
 
-    //Serial.printf("\nY: %d, M: %d, D: %d, h: %d, m: %d, s: %d, deviation: 0x%2X, status: 0x%1X\n", tm.Year, tm.Month, tm.Day, tm.Hour, tm.Minute, tm.Second, timestamp.deviation, timestamp.status);
-
     time_t time = makeTime(tm);
     int16_t deviation = ntohs(timestamp.deviation);
     if(deviation >= -720 && deviation <= 720) {

--- a/lib/MeterCommunicators/include/IEC6205675.h
+++ b/lib/MeterCommunicators/include/IEC6205675.h
@@ -11,6 +11,9 @@
 #include "AmsConfiguration.h"
 #include "DataParser.h"
 #include "Cosem.h"
+#if defined(AMS_REMOTE_DEBUG)
+#include "RemoteDebug.h"
+#endif
 
 #define NOVALUE 0xFFFFFFFF
 
@@ -21,7 +24,11 @@ struct AmsOctetTimestamp {
 
 class IEC6205675 : public AmsData {
 public:
-    IEC6205675(const char* payload, uint8_t useMeterType, MeterConfig* meterConfig, DataParserContext &ctx, AmsData &state);
+    #if defined(AMS_REMOTE_DEBUG)
+    IEC6205675(const char* payload, uint8_t useMeterType, MeterConfig* meterConfig, DataParserContext &ctx, AmsData &state, RemoteDebug* debugger);
+    #else
+    IEC6205675(const char* payload, uint8_t useMeterType, MeterConfig* meterConfig, DataParserContext &ctx, AmsData &state, Stream* debugger);
+    #endif
 
 private:
     CosemData* getCosemDataAt(uint8_t index, const char* ptr);

--- a/lib/MeterCommunicators/src/IEC6205675.cpp
+++ b/lib/MeterCommunicators/src/IEC6205675.cpp
@@ -635,12 +635,6 @@ IEC6205675::IEC6205675(const char* d, uint8_t useMeterType, MeterConfig* meterCo
             } 
         }
 
-        if(this->packageTimestamp > 0) {
-            if(meterType == AmsTypeKamstrup) {
-                this->packageTimestamp = this->packageTimestamp - 3600;
-            }
-        }
-
         uint8_t str_len = 0;
         str_len = getString(AMS_OBIS_VERSION, sizeof(AMS_OBIS_VERSION), ((char *) (d)), str);
         if(str_len > 0) {
@@ -741,8 +735,11 @@ IEC6205675::IEC6205675(const char* d, uint8_t useMeterType, MeterConfig* meterCo
         if(meterTs != NULL) {
             AmsOctetTimestamp* amst = (AmsOctetTimestamp*) meterTs;
             time_t ts = decodeCosemDateTime(amst->dt);
-            if(amst->dt.deviation == 0x8000) { // Deviation not specified, adjust from localtime to UTC
+            if(amst->dt.deviation == ((int16_t) 0x8000)) { // Deviation not specified, adjust from localtime to UTC
                 meterTimestamp = tz.toUTC(ts);
+                if(ctx.timestamp > 0) {
+                    this->packageTimestamp = tz.toUTC(ctx.timestamp);
+                }
             } else if(meterType == AmsTypeAidon) {
                 meterTimestamp = ts - 3600; // 21.09.24, the clock is now correct
             } else {

--- a/lib/MeterCommunicators/src/PassiveMeterCommunicator.cpp
+++ b/lib/MeterCommunicators/src/PassiveMeterCommunicator.cpp
@@ -278,7 +278,7 @@ AmsData* PassiveMeterCommunicator::getData(AmsData& meterState) {
 			#endif
 			debugger->printf_P(PSTR("DLMS\n"));
 			// TODO: Split IEC6205675 into DataParserKaifa and DataParserObis. This way we can add other means of parsing, for those other proprietary formats
-			data = new IEC6205675(payload, meterState.getMeterType(), &meterConfig, ctx, meterState);
+			data = new IEC6205675(payload, meterState.getMeterType(), &meterConfig, ctx, meterState, debugger);
 		}
 	} else if(ctx.type == DATA_TAG_DSMR) {
 		data = new IEC6205621(payload, tz, &meterConfig);


### PR DESCRIPTION
Kamstrup sends timestamps without time zone (Like many other) and we have to convert the time into UTC timestamps to make them right