### PR TITLE
Fixed duplicate device UID in HA when using Ethernet

### DIFF
--- a/lib/HomeAssistantMqttHandler/include/HomeAssistantMqttHandler.h
+++ b/lib/HomeAssistantMqttHandler/include/HomeAssistantMqttHandler.h
@@ -15,13 +15,13 @@
 class HomeAssistantMqttHandler : public AmsMqttHandler {
 public:
     #if defined(AMS_REMOTE_DEBUG)
-    HomeAssistantMqttHandler(MqttConfig& mqttConfig, RemoteDebug* debugger, char* buf, uint8_t boardType, HomeAssistantConfig config, HwTools* hw, AmsFirmwareUpdater* updater) : AmsMqttHandler(mqttConfig, debugger, buf, updater) {
+    HomeAssistantMqttHandler(MqttConfig& mqttConfig, RemoteDebug* debugger, char* buf, uint8_t boardType, HomeAssistantConfig config, HwTools* hw, AmsFirmwareUpdater* updater, char* hostname) : AmsMqttHandler(mqttConfig, debugger, buf, updater) {
     #else
     HomeAssistantMqttHandler(MqttConfig& mqttConfig, Stream* debugger, char* buf, uint8_t boardType, HomeAssistantConfig config, HwTools* hw) : AmsMqttHandler(mqttConfig, debugger, buf) {
     #endif
         this->boardType = boardType;
         this->hw = hw;
-        setHomeAssistantConfig(config);
+        setHomeAssistantConfig(config, hostname);
     };
     bool publish(AmsData* data, AmsData* previousState, EnergyAccounting* ea, PriceService* ps);
     bool publishTemperatures(AmsConfiguration*, HwTools*);
@@ -36,7 +36,7 @@ public:
 
     uint8_t getFormat();
 
-    void setHomeAssistantConfig(HomeAssistantConfig config);
+    void setHomeAssistantConfig(HomeAssistantConfig config, char* hostname);
 private:
     uint8_t boardType;
 

--- a/lib/HomeAssistantMqttHandler/src/HomeAssistantMqttHandler.cpp
+++ b/lib/HomeAssistantMqttHandler/src/HomeAssistantMqttHandler.cpp
@@ -19,7 +19,7 @@
 #include <esp_task_wdt.h>
 #endif
 
-void HomeAssistantMqttHandler::setHomeAssistantConfig(HomeAssistantConfig config) {
+void HomeAssistantMqttHandler::setHomeAssistantConfig(HomeAssistantConfig config, char* hostname) {
     l1Init = l2Init = l2eInit = l3Init = l3eInit = l4Init = l4eInit = rtInit = rteInit = pInit = sInit = rInit = fInit = false;
 
     pubTopic = String(mqttConfig.publishTopic);
@@ -38,14 +38,6 @@ void HomeAssistantMqttHandler::setHomeAssistantConfig(HomeAssistantConfig config
     deviceModel = boardTypeToString(boardType);
     manufacturer = boardManufacturerToString(boardType);
 
-    char hostname[32];
-    #if defined(ESP8266)
-        strcpy(hostname, WiFi.hostname().c_str());
-    #elif defined(ESP32)
-        strcpy(hostname, WiFi.getHostname());
-    #endif
-
-    stripNonAscii((uint8_t*) hostname, 32, false);
     deviceUid = String(hostname); // Maybe configurable in the future?
 
     if(strlen(config.discoveryHostname) > 0) {

--- a/src/AmsToMqttBridge.cpp
+++ b/src/AmsToMqttBridge.cpp
@@ -1547,8 +1547,10 @@ void MQTT_connect() {
 				case 4: {
 					HomeAssistantConfig haconf;
 					config.getHomeAssistantConfig(haconf);
+					NetworkConfig network;
+					ch->getCurrentConfig(network);
 					HomeAssistantMqttHandler* hamh = (HomeAssistantMqttHandler*) &mqttHandler;
-					hamh->setHomeAssistantConfig(haconf);
+					hamh->setHomeAssistantConfig(haconf, network.hostname);
 					break;
 				}
 			}
@@ -1574,7 +1576,9 @@ void MQTT_connect() {
 			case 4:
 				HomeAssistantConfig haconf;
 				config.getHomeAssistantConfig(haconf);
-				mqttHandler = new HomeAssistantMqttHandler(mqttConfig, &Debug, (char*) commonBuffer, sysConfig.boardType, haconf, &hw, &updater);
+				NetworkConfig network;
+				ch->getCurrentConfig(network);
+				mqttHandler = new HomeAssistantMqttHandler(mqttConfig, &Debug, (char*) commonBuffer, sysConfig.boardType, haconf, &hw, &updater, network.hostname);
 				break;
 			case 255:
 				mqttHandler = new PassthroughMqttHandler(mqttConfig, &Debug, (char*) commonBuffer, &updater);


### PR DESCRIPTION
The HA implementation was using `WiFi.getHostname()` to generate the device UID. Changed this to use the configured hostname instead.