### PR TITLE
Include device information when asking for new version

### DIFF
--- a/lib/AmsFirmwareUpdater/src/AmsFirmwareUpdater.cpp
+++ b/lib/AmsFirmwareUpdater/src/AmsFirmwareUpdater.cpp
@@ -230,6 +230,16 @@ bool AmsFirmwareUpdater::fetchNextVersion() {
         http.setUserAgent("AMS-Firmware-Updater");
         http.addHeader(F("Cache-Control"), "no-cache");
         http.addHeader(F("x-AMS-version"), FirmwareVersion::VersionString);
+        http.addHeader(F("x-AMS-STA-MAC"), WiFi.macAddress());
+        http.addHeader(F("x-AMS-AP-MAC"), WiFi.softAPmacAddress());
+        http.addHeader(F("x-AMS-chip-size"), String(ESP.getFlashChipSize()));
+		http.addHeader(F("x-AMS-board-type"), String(hw->getBoardType(), 10));
+		if(meterState->getMeterType() != AmsTypeAutodetect) {
+			http.addHeader(F("x-AMS-meter-mfg"), String(meterState->getMeterType(), 10));
+		}
+		if(!meterState->getMeterModel().isEmpty()) {
+			http.addHeader(F("x-AMS-meter-model"), meterState->getMeterModel());
+		}
         int status = http.GET();
         if(status == 204) {
             String nextVersion = http.header("x-version");


### PR DESCRIPTION
These changes will help us with two things:
1. The firmware will always check next release shortly after boot, which means that after a firmware upgrade it will let us know if the device was successfully upgraded. As a start this will give us a statistical benefit, but could also help us in support cases in the future.
2. Since we are including board type and meter manufacturer and model, we can control the firmware roll-out for specific boards or meters. The reasoning for this could either be known bugs for certain meters or to limit the speed of a roll-out, either to control the load on the server or to portion the roll-out in phases.