### PR TITLE
Fixed default MQTT subscription

### DIFF
--- a/lib/AmsMqttHandler/include/AmsMqttHandler.h
+++ b/lib/AmsMqttHandler/include/AmsMqttHandler.h
@@ -43,6 +43,7 @@ public:
     void setConfig(MqttConfig& mqttConfig);
 
     bool connect();
+    bool defaultSubscribe();
     void disconnect();
     lwmqtt_err_t lastError();
     bool connected();

--- a/lib/AmsMqttHandler/src/AmsMqttHandler.cpp
+++ b/lib/AmsMqttHandler/src/AmsMqttHandler.cpp
@@ -127,6 +127,7 @@ bool AmsMqttHandler::connect() {
 		mqtt.onMessage(std::bind(&AmsMqttHandler::onMessage, this, std::placeholders::_1, std::placeholders::_2));
 		mqtt.publish(statusTopic, "online", true, 0);
         mqtt.loop();
+		defaultSubscribe();
 		postConnect();
         return true;
 	} else {
@@ -144,6 +145,25 @@ bool AmsMqttHandler::connect() {
 		}
         return false;
 	}
+}
+
+bool AmsMqttHandler::defaultSubscribe() {
+	bool ret = true;
+	if(!subTopic.isEmpty()) {
+        if(mqtt.subscribe(subTopic)) {
+            #if defined(AMS_REMOTE_DEBUG)
+            if (debugger->isActive(RemoteDebug::ERROR))
+            #endif
+            debugger->printf_P(PSTR("  Subscribed to [%s]\n"), subTopic.c_str());
+        } else {
+            #if defined(AMS_REMOTE_DEBUG)
+            if (debugger->isActive(RemoteDebug::ERROR))
+            #endif
+            debugger->printf_P(PSTR("  Unable to subscribe to [%s]\n"), subTopic.c_str());
+            ret = false;
+        }
+    }
+	return ret;
 }
 
 void AmsMqttHandler::disconnect() {

--- a/lib/HomeAssistantMqttHandler/src/HomeAssistantMqttHandler.cpp
+++ b/lib/HomeAssistantMqttHandler/src/HomeAssistantMqttHandler.cpp
@@ -70,14 +70,22 @@ void HomeAssistantMqttHandler::setHomeAssistantConfig(HomeAssistantConfig config
 }
 
 bool HomeAssistantMqttHandler::postConnect() {
-    if(!subTopic.isEmpty() && !mqtt.subscribe(subTopic)) {
-        #if defined(AMS_REMOTE_DEBUG)
-        if (debugger->isActive(RemoteDebug::ERROR))
-        #endif
-        debugger->printf_P(PSTR("  Unable to subscribe to to [%s]\n"), subTopic.c_str());
-        return false;
+    bool ret = true;
+    if(!statusTopic.isEmpty()) {
+        if(mqtt.subscribe(statusTopic)) {
+            #if defined(AMS_REMOTE_DEBUG)
+            if (debugger->isActive(RemoteDebug::ERROR))
+            #endif
+            debugger->printf_P(PSTR("  Subscribed to [%s]\n"), statusTopic.c_str());
+        } else {
+            #if defined(AMS_REMOTE_DEBUG)
+            if (debugger->isActive(RemoteDebug::ERROR))
+            #endif
+            debugger->printf_P(PSTR("  Unable to subscribe to [%s]\n"), statusTopic.c_str());
+            ret = false;
+        }
     }
-    return true;
+    return ret;
 }
 
 bool HomeAssistantMqttHandler::publish(AmsData* update, AmsData* previousState, EnergyAccounting* ea, PriceService* ps) {

--- a/lib/JsonMqttHandler/include/JsonMqttHandler.h
+++ b/lib/JsonMqttHandler/include/JsonMqttHandler.h
@@ -26,8 +26,6 @@ public:
     bool publishRaw(String data);
     bool publishFirmware();
 
-    bool postConnect();
-
     void onMessage(String &topic, String &payload);
 
     uint8_t getFormat();

--- a/lib/JsonMqttHandler/src/JsonMqttHandler.cpp
+++ b/lib/JsonMqttHandler/src/JsonMqttHandler.cpp
@@ -10,17 +10,6 @@
 #include "Uptime.h"
 #include "AmsJsonGenerator.h"
 
-bool JsonMqttHandler::postConnect() {
-    if(!subTopic.isEmpty() && !mqtt.subscribe(subTopic)) {
-        #if defined(AMS_REMOTE_DEBUG)
-        if (debugger->isActive(RemoteDebug::ERROR))
-        #endif
-        debugger->printf_P(PSTR("  Unable to subscribe to to [%s]\n"), subTopic.c_str());
-        return false;
-    }
-    return true;
-}
-
 bool JsonMqttHandler::publish(AmsData* update, AmsData* previousState, EnergyAccounting* ea, PriceService* ps) {
     if(strlen(mqttConfig.publishTopic) == 0) {
         return false;


### PR DESCRIPTION
Sending commands to the device via MQTT is possible for Home-Assistant, JSON and RAW. By default the device should listen to `<subscribe topic>/command` if nothing is specified, but this have only  been the case for Home-Assistant. Moving the subscribe code back to the main class `AmsMqttHandler` and letting `postConnect()` method handle any other specific subscriptions like the status topic for Home-Assistant.