### PR TITLE
Fixed reboot loop for some meters

### DIFF
--- a/lib/MeterCommunicators/include/PassiveMeterCommunicator.h
+++ b/lib/MeterCommunicators/include/PassiveMeterCommunicator.h
@@ -36,6 +36,9 @@ public:
     bool isConfigChanged();
     void ackConfigChanged();
     void getCurrentConfig(MeterConfig& meterConfig);
+    void setTimezone(Timezone* tz) {
+        this->tz = tz;
+    };
 
     HardwareSerial* getHwSerial();
     void rxerr(int err);

--- a/lib/MeterCommunicators/src/IEC6205675.cpp
+++ b/lib/MeterCommunicators/src/IEC6205675.cpp
@@ -27,13 +27,13 @@ IEC6205675::IEC6205675(const char* d, Timezone* tz, uint8_t useMeterType, MeterC
         
         // Kaifa special case...
         if(useMeterType == AmsTypeKaifa && data->base.type == CosemTypeDLongUnsigned) {
-            this->packageTimestamp = this->packageTimestamp > 0 ? tz->toUTC(this->packageTimestamp) : 0;
+            this->packageTimestamp = this->packageTimestamp > 0 && tz != NULL ? tz->toUTC(this->packageTimestamp) : 0;
             listType = 1;
             meterType = AmsTypeKaifa;
             activeImportPower = ntohl(data->dlu.data);
             lastUpdateMillis = millis64();
         } else if(data->base.type == CosemTypeOctetString) {
-            this->packageTimestamp = this->packageTimestamp > 0 ? tz->toUTC(this->packageTimestamp) : 0;
+            this->packageTimestamp = this->packageTimestamp > 0 && tz != NULL ? tz->toUTC(this->packageTimestamp) : 0;
 
             memcpy(str, data->oct.data, data->oct.length);
             str[data->oct.length] = 0x00;
@@ -123,7 +123,7 @@ IEC6205675::IEC6205675(const char* d, Timezone* tz, uint8_t useMeterType, MeterC
                             if(data->oct.length == 0x0C) {
                                 AmsOctetTimestamp* amst = (AmsOctetTimestamp*) data;
                                 time_t ts = decodeCosemDateTime(amst->dt);
-                                meterTimestamp = tz->toUTC(ts);
+                                meterTimestamp = tz != NULL ? tz->toUTC(ts) : ts;
                             }
                         }
                     }
@@ -1121,7 +1121,7 @@ time_t IEC6205675::adjustForKnownIssues(CosemDateTime dt, Timezone* tz, uint8_t 
             // 21.09.24, the clock is now correct for Aidon
             // 23.10.25, the clock is now correct for Kamstrup
             ts -= 3600;
-        } else {
+        } else if(tz != NULL) {
             // Adjust from localtime to UTC
             ts = tz->toUTC(ts);
         }

--- a/lib/SvelteUi/app/translations.json
+++ b/lib/SvelteUi/app/translations.json
@@ -16,7 +16,8 @@
         "day" : "day",
         "days" : "days",
         "month" : "month",
-        "unknown" : "Unknown"
+        "unknown" : "Unknown",
+        "now" : "Now"
     },
     "btn" : {
         "reboot" : "Reboot",

--- a/src/AmsToMqttBridge.cpp
+++ b/src/AmsToMqttBridge.cpp
@@ -809,6 +809,9 @@ void handleNtp() {
 			ds.setTimezone(tz);
 			ea.setTimezone(tz);
 			ps->setTimezone(tz);
+			if(passiveMc != NULL) {
+				passiveMc->setTimezone(tz);
+			}
 		}
 	
 		config.ackNtpChange();


### PR DESCRIPTION
Related to #1011 

Timezone was not properly set into the object, which led to a null-pointer for certain meters. This change introduces a null check as well as a setter that is used when timezone is changed.