### PR TITLE
Added support for frames without checksum

### DIFF
--- a/lib/AmsDecoder/src/DsmrParser.cpp
+++ b/lib/AmsDecoder/src/DsmrParser.cpp
@@ -74,7 +74,7 @@ int8_t DSMRParser::parse(uint8_t *buf, DataParserContext &ctx, bool verified, Pr
         fromHex((uint8_t*) &crc, String((char*) buf+crcPos), 2);
         crc = ntohs(crc);
 
-        if(crc != crc_calc) {
+        if(crc > 0 && crc != crc_calc) {
             if(debugger != NULL) {
                 debugger->printf_P(PSTR("CRC incorrrect, %04X != %04X at position %lu\n"), crc, crc_calc, crcPos);
             }

--- a/lib/AmsDecoder/src/HdlcParser.cpp
+++ b/lib/AmsDecoder/src/HdlcParser.cpp
@@ -32,7 +32,7 @@ int8_t HDLCParser::parse(uint8_t *d, DataParserContext &ctx) {
             return DATA_PARSE_BOUNDARY_FLAG_MISSING;
 
         // Verify FCS
-        if(ntohs(f->fcs) != crc16_x25(d + 1, len - sizeof *f - 1))
+        if(f->fcs > 0 && ntohs(f->fcs) != crc16_x25(d + 1, len - sizeof *f - 1))
             return DATA_PARSE_FOOTER_CHECKSUM_ERROR;
 
         // Skip destination address, LSB marks last byte
@@ -50,7 +50,7 @@ int8_t HDLCParser::parse(uint8_t *d, DataParserContext &ctx) {
         HDLC3CtrlHcs* t3 = (HDLC3CtrlHcs*) (ptr);
 
         // Verify HCS
-        if(ntohs(t3->hcs) != crc16_x25(d + 1, ptr-d))
+        if(t3->hcs > 0 && ntohs(t3->hcs) != crc16_x25(d + 1, ptr-d))
             return DATA_PARSE_HEADER_CHECKSUM_ERROR;
         ptr += 3;
 


### PR DESCRIPTION
A Iskraemeco meter was sending data without checksum. Supporting this by only confirming checksum if it is different from 0x0000

Fixes: #1037