### PR TITLE
Fixed deprecated object_id for Home-Assistant sensor

### DIFF
--- a/lib/HomeAssistantMqttHandler/json/hadiscover.json
+++ b/lib/HomeAssistantMqttHandler/json/hadiscover.json
@@ -2,7 +2,7 @@
     "name" : "%s%s",
     "stat_t" : "%s%s",
     "uniq_id" : "%s_%s",
-    "obj_id" : "%s_%s",
+    "default_entity_id" : "sensor.%s_%s",
     "val_tpl" : "{{ value_json.%s | is_defined }}",
     "expire_after" : %d,
     "dev" : {


### PR DESCRIPTION
Lately Home-Assistant have been complaining about the use of `object_id` (or actually `obj_id`) in the sensor configuration that the firmware sends to HA.

This update changes f.ex. `obj_id:ams-b56_P` to `default_entity_id:sensor.ams-b56_P`.