### PR TITLE
Fixed incorrect color LED on boot

### DIFF
--- a/src/AmsToMqttBridge.cpp
+++ b/src/AmsToMqttBridge.cpp
@@ -378,6 +378,10 @@ void setup() {
 
 	delay(1);
 	hw.setup(&sysConfig, &gpioConfig);
+	hw.ledOff(LED_INTERNAL);
+	hw.ledOff(LED_RED);
+	hw.ledOff(LED_GREEN);
+	hw.ledOff(LED_BLUE);
 
 	if(gpioConfig.apPin >= 0) {
 		pinMode(gpioConfig.apPin, INPUT_PULLUP);


### PR DESCRIPTION
LED is supposed to be green for 1s on boot to indicate when to hit AP button to trigger emergency factory reset. Instead this have become yellow at some point by accident. Explicitly turning off all LED colors after configuring GPIO fixes the problem.