### PR TITLE
Fix uninitialized loop variable in GcmParser (undefined behavior in authentication check)

### DIFF
--- a/lib/AmsDecoder/src/GcmParser.cpp
+++ b/lib/AmsDecoder/src/GcmParser.cpp
@@ -96,7 +96,7 @@ int8_t GCMParser::parse(uint8_t *d, DataParserContext &ctx, bool hastag) {
         footersize += authkeylen;
         memcpy(additional_authenticated_data + 1, authentication_key, 16);
         memcpy(authentication_tag, ptr + len - footersize - 5, authkeylen);
-        for(uint8_t i; i < 16; i++) authenticate |= authentication_key[i] > 0;
+        for(uint8_t i = 0; i < 16; i++) authenticate |= authentication_key[i] > 0;
     }
 
     #if defined(ESP8266)


### PR DESCRIPTION
## Problem

Encrypted Kamstrup meters (and other meters with authentication keys) report **"HAN: Unknown data received"** even when keys are correctly configured.

Closes #1164

## Root Cause

`lib/AmsDecoder/src/GcmParser.cpp` line 99 has an uninitialized loop variable:

```cpp
// Before (bug):
for(uint8_t i; i < 16; i++) authenticate |= authentication_key[i] > 0;
```

`i` is declared but never initialized — undefined behavior in C++. When `i` starts at ≥ 16 (depending on stack contents), the loop never executes, `authenticate` stays `false`, and decryption proceeds without authentication even when an auth key is configured. This produces garbage output that fails all subsequent parsing.

## Fix

```cpp
// After (fix):
for(uint8_t i = 0; i < 16; i++) authenticate |= authentication_key[i] > 0;
```

## Testing

Verified against a Kamstrup Omnipower meter (Danish grid, GPK60 auth key) running on ESP8266. Before fix: "Unknown data received". After fix: frames decrypt and parse correctly.

## Related

- Related to #720 (GCM auth tag handling in GcmParser)
- Related to #862 (Kamstrup "unknown data received" post-update)