### PR TITLE
Extend tariff 1 & 2 counter coverage to DSMR and more DLMS paths

### DIFF
--- a/lib/MeterCommunicators/src/IEC6205621.cpp
+++ b/lib/MeterCommunicators/src/IEC6205621.cpp
@@ -132,6 +132,10 @@ IEC6205621::IEC6205621(const char* p, Timezone* tz, MeterConfig* meterConfig) {
 
 	double val = 0.0;
 	
+	double it1 = extractDouble(payload, F("1.8.1"));
+	double it2 = extractDouble(payload, F("1.8.2"));
+	if(it1 > 0) activeImportCounterTariff1 = it1 / 1000;
+	if(it2 > 0) activeImportCounterTariff2 = it2 / 1000;
 	val = extractDouble(payload, F("1.8.0"));
 	if(val == 0) {
 		for(int i = 1; i < 9; i++) {
@@ -140,6 +144,10 @@ IEC6205621::IEC6205621(const char* p, Timezone* tz, MeterConfig* meterConfig) {
 	}
 	if(val > 0) activeImportCounter = val / 1000;
 
+	double et1 = extractDouble(payload, F("2.8.1"));
+	double et2 = extractDouble(payload, F("2.8.2"));
+	if(et1 > 0) activeExportCounterTariff1 = et1 / 1000;
+	if(et2 > 0) activeExportCounterTariff2 = et2 / 1000;
 	val = extractDouble(payload, F("2.8.0"));
 	if(val == 0) {
 		for(int i = 1; i < 9; i++) {
@@ -188,7 +196,11 @@ IEC6205621::IEC6205621(const char* p, Timezone* tz, MeterConfig* meterConfig) {
     }
     if(meterConfig->accumulatedMultiplier > 0) {
         activeImportCounter = activeImportCounter > 0 ? activeImportCounter * (meterConfig->accumulatedMultiplier / 1000.0) : 0;
+        activeImportCounterTariff1 = activeImportCounterTariff1 > 0 ? activeImportCounterTariff1 * (meterConfig->accumulatedMultiplier / 1000.0) : 0;
+        activeImportCounterTariff2 = activeImportCounterTariff2 > 0 ? activeImportCounterTariff2 * (meterConfig->accumulatedMultiplier / 1000.0) : 0;
         activeExportCounter = activeExportCounter > 0 ? activeExportCounter * (meterConfig->accumulatedMultiplier / 1000.0) : 0;
+        activeExportCounterTariff1 = activeExportCounterTariff1 > 0 ? activeExportCounterTariff1 * (meterConfig->accumulatedMultiplier / 1000.0) : 0;
+        activeExportCounterTariff2 = activeExportCounterTariff2 > 0 ? activeExportCounterTariff2 * (meterConfig->accumulatedMultiplier / 1000.0) : 0;
         reactiveImportCounter = reactiveImportCounter > 0 ? reactiveImportCounter * (meterConfig->accumulatedMultiplier / 1000.0) : 0;
         reactiveExportCounter = reactiveExportCounter > 0 ? reactiveExportCounter * (meterConfig->accumulatedMultiplier / 1000.0) : 0;
     }

--- a/lib/MeterCommunicators/src/IEC6205675.cpp
+++ b/lib/MeterCommunicators/src/IEC6205675.cpp
@@ -471,6 +471,8 @@ IEC6205675::IEC6205675(const char* d, Timezone* tz, uint8_t useMeterType, MeterC
                     data = getCosemDataAt(idx++, ((char *) (d)));
                     double obis282 = ntohl(data->dlu.data) / 1000.0;
 
+                    activeExportCounterTariff1 = obis281;
+                    activeExportCounterTariff2 = obis282;
                     activeExportCounter = obis281 + obis282;
 
                     lastUpdateMillis = millis64();
@@ -879,10 +881,30 @@ IEC6205675::IEC6205675(const char* d, Timezone* tz, uint8_t useMeterType, MeterC
             listType = 3;
             activeImportCounter = val / 1000.0;
         }
+        val = getNumber(AMS_OBIS_ACTIVE_IMPORT_COUNT_T1, sizeof(AMS_OBIS_ACTIVE_IMPORT_COUNT_T1), ((char *) (d)));
+        if(val != NOVALUE) {
+            listType = 3;
+            activeImportCounterTariff1 = val / 1000.0;
+        }
+        val = getNumber(AMS_OBIS_ACTIVE_IMPORT_COUNT_T2, sizeof(AMS_OBIS_ACTIVE_IMPORT_COUNT_T2), ((char *) (d)));
+        if(val != NOVALUE) {
+            listType = 3;
+            activeImportCounterTariff2 = val / 1000.0;
+        }
         val = getNumber(AMS_OBIS_ACTIVE_EXPORT_COUNT, sizeof(AMS_OBIS_ACTIVE_EXPORT_COUNT), ((char *) (d)));
         if(val != NOVALUE) {
             listType = 3;
             activeExportCounter = val / 1000.0;
+        }
+        val = getNumber(AMS_OBIS_ACTIVE_EXPORT_COUNT_T1, sizeof(AMS_OBIS_ACTIVE_EXPORT_COUNT_T1), ((char *) (d)));
+        if(val != NOVALUE) {
+            listType = 3;
+            activeExportCounterTariff1 = val / 1000.0;
+        }
+        val = getNumber(AMS_OBIS_ACTIVE_EXPORT_COUNT_T2, sizeof(AMS_OBIS_ACTIVE_EXPORT_COUNT_T2), ((char *) (d)));
+        if(val != NOVALUE) {
+            listType = 3;
+            activeExportCounterTariff2 = val / 1000.0;
         }
         val = getNumber(AMS_OBIS_REACTIVE_IMPORT_COUNT, sizeof(AMS_OBIS_REACTIVE_IMPORT_COUNT), ((char *) (d)));
         if(val != NOVALUE) {
@@ -1095,7 +1117,11 @@ IEC6205675::IEC6205675(const char* d, Timezone* tz, uint8_t useMeterType, MeterC
     }
     if(meterConfig->accumulatedMultiplier > 0) {
         activeImportCounter = activeImportCounter > 0 ? activeImportCounter * (meterConfig->accumulatedMultiplier / 1000.0) : 0;
+        activeImportCounterTariff1 = activeImportCounterTariff1 > 0 ? activeImportCounterTariff1 * (meterConfig->accumulatedMultiplier / 1000.0) : 0;
+        activeImportCounterTariff2 = activeImportCounterTariff2 > 0 ? activeImportCounterTariff2 * (meterConfig->accumulatedMultiplier / 1000.0) : 0;
         activeExportCounter = activeExportCounter > 0 ? activeExportCounter * (meterConfig->accumulatedMultiplier / 1000.0) : 0;
+        activeExportCounterTariff1 = activeExportCounterTariff1 > 0 ? activeExportCounterTariff1 * (meterConfig->accumulatedMultiplier / 1000.0) : 0;
+        activeExportCounterTariff2 = activeExportCounterTariff2 > 0 ? activeExportCounterTariff2 * (meterConfig->accumulatedMultiplier / 1000.0) : 0;
         reactiveImportCounter = reactiveImportCounter > 0 ? reactiveImportCounter * (meterConfig->accumulatedMultiplier / 1000.0) : 0;
         reactiveExportCounter = reactiveExportCounter > 0 ? reactiveExportCounter * (meterConfig->accumulatedMultiplier / 1000.0) : 0;
         l1activeImportCounter = l1activeImportCounter > 0 ? l1activeImportCounter * (meterConfig->accumulatedMultiplier / 1000.0) : 0;


### PR DESCRIPTION
Follow-up to #1136, which added Tariff 1 & 2 import/export counters but only sourced them from the LNG parser and one IEC6205675 (Iskra) list path. This PR extends the same counters to the remaining payload types that expose tariff registers.

## Changes

### DSMR / P1 (`IEC6205621`)
The most common dual-tariff family (NL/BE/LU day–night meters). The parser already read `1.8.1`/`1.8.2` and `2.8.1`/`2.8.2` but only **summed them into the totals** — the per-tariff breakdown was discarded (the same "read but not stored" bug #1136 fixed for LNG).
- Read `1.8.1`/`1.8.2` and `2.8.1`/`2.8.2` into the tariff counters, guarded so absent registers don't zero known values.
- Apply `accumulatedMultiplier` scaling to the tariff counters, matching the totals.

### DLMS (`IEC6205675`)
- **Wired up the `AMS_OBIS_*_COUNT_T1/T2` OBIS constants** in the generic OBIS-lookup path. #1136 declared these constants but never used them; now any list exposing `1.8.1/1.8.2/2.8.1/2.8.2` via OBIS tags populates the tariff counters.
- Store export tariff values in the Iskra export-list path that already parsed `obis281/282`.
- Apply `accumulatedMultiplier` scaling to the tariff counters.

## Output
No new plumbing needed — the MQTT (`tPIT1/tPIT2/tPOT1/tPOT2`), Raw (`.../tariff1`, `.../tariff2`), and UI (`ict1/ict2/ect1/ect2`) layers from #1136 read the `AmsData` tariff getters, so these parsers' values flow through automatically.

## Scope / deliberately left alone
- IEC6205675 list paths that only read `1.8.0`/`2.8.0` totals, or that skip the tariff positions with uncertain (commented `?`) layout, are **untouched** — adding reads there without validated payloads risks writing garbage into tariff counters.
- `LNG2` and the Kamstrup (KMP) driver expose only total registers — nothing to source.

## Testing
- Builds: `esp32` and `esp8266` both succeed.
- No host unit test: the native decoder harness isn't on `main` (it comes with the planned restructure), and `IEC6205621` is built on Arduino `String`. Verified by build + code review against the OBIS register definitions. Real-meter validation (DSMR dual-tariff + an Iskra) recommended before release.