### PR TITLE
Non-blocking LED flashing with slow error codes and meter-LED suppression

### DIFF
--- a/src/AmsToMqttBridge.cpp
+++ b/src/AmsToMqttBridge.cpp
@@ -383,7 +383,7 @@ void setup() {
 		delay(1000);
 		if(digitalRead(gpioConfig.apPin) == LOW) {
 			if(!hw.ledOn(LED_RED)) {
-				hw.ledBlink(LED_INTERNAL, 4);
+				hw.ledFlashBlocking(LED_INTERNAL, 4);
 			}
 			delay(2000);
 			if(digitalRead(gpioConfig.apPin) == LOW) {
@@ -393,8 +393,8 @@ void setup() {
 				delay(2000);
 				if(digitalRead(gpioConfig.apPin) == HIGH) {
 					config.clear();
-					if(!hw.ledBlink(LED_RED, 6)) {
-						hw.ledBlink(LED_INTERNAL, 6);
+					if(!hw.ledFlashBlocking(LED_RED, 6)) {
+						hw.ledFlashBlocking(LED_INTERNAL, 6);
 					}
 					rdc.cause = REBOOT_CAUSE_BTN_FACTORY_RESET;
 					delay(250);
@@ -523,11 +523,11 @@ void setup() {
 	hw.ledOff(LED_GREEN);
 	hw.ledOff(LED_INTERNAL);
 
-	hw.ledBlink(LED_INTERNAL, 1);
-	hw.ledBlink(LED_RED, 1);
-	hw.ledBlink(LED_YELLOW, 1);
-	hw.ledBlink(LED_GREEN, 1);
-	hw.ledBlink(LED_BLUE, 1);
+	hw.ledFlashBlocking(LED_INTERNAL, 1);
+	hw.ledFlashBlocking(LED_RED, 1);
+	hw.ledFlashBlocking(LED_YELLOW, 1);
+	hw.ledFlashBlocking(LED_GREEN, 1);
+	hw.ledFlashBlocking(LED_BLUE, 1);
 
 	WiFi.disconnect(true);
 	WiFi.softAPdisconnect(true);
@@ -661,7 +661,8 @@ void loop() {
 
 	handleButton(now);
 
-	if(now > 10000 && now - lastErrorBlink > 3000) {
+	hw.ledLoop();
+	if(now > 10000 && !hw.ledBusy() && now - lastErrorBlink > 3000) {
 		errorBlink();
 	}
 
@@ -1348,7 +1349,7 @@ void errorBlink() {
 			case 0:
 				if(lastErrorBlink - meterState.getLastUpdateMillis() > 30000) {
 					debugW_P(PSTR("No HAN data received last 30s, single blink"));
-					hw.ledBlink(LED_RED, 1); // If no message received from AMS in 30 sec, blink once
+					hw.ledFlash(LED_RED, 1, false, true); // If no message received from AMS in 30 sec, slow blink once
 					if(meterState.getLastError() == 0) meterState.setLastError(METER_ERROR_NO_DATA);
 					return;
 				}
@@ -1356,14 +1357,14 @@ void errorBlink() {
 			case 1:
 				if(mqttHandler != NULL && mqttHandler->lastError() != 0) {
 					debugW_P(PSTR("MQTT connection not available, double blink"));
-					hw.ledBlink(LED_RED, 2); // If MQTT error, blink twice
+					hw.ledFlash(LED_RED, 2, false, true); // If MQTT error, slow blink twice
 					return;
 				}
 				break;
 			case 2:
 				if(WiFi.getMode() == WIFI_STA && WiFi.status() != WL_CONNECTED) {
 					debugW_P(PSTR("WiFi not connected, tripe blink"));
-					hw.ledBlink(LED_RED, 3); // If WiFi not connected, blink three times
+					hw.ledFlash(LED_RED, 3, false, true); // If WiFi not connected, slow blink three times
 					return;
 				}
 				break;
@@ -1542,8 +1543,8 @@ bool readHanPort() {
 }
 
 void handleDataSuccess(AmsData* data) {
-	if(!setupMode && !hw.ledBlink(LED_GREEN, 1))
-		hw.ledBlink(LED_INTERNAL, 1);
+	if(!setupMode && !hw.ledFlash(LED_GREEN, 1))
+		hw.ledFlash(LED_INTERNAL, 1);
 
 	if(mqttHandler != NULL && checkVoltageIfNeeded(0.2)) {
 		#if defined(ESP32)

--- a/src/HwTools.cpp
+++ b/src/HwTools.cpp
@@ -554,26 +554,27 @@ int HwTools::getWifiRssi() {
     return isnan(rssi) ? -100.0 : rssi;
 }
 
+// Drive the LED-disable pin to its normal state for the current behaviour.
+// LOW disables the hardwired (meter-activity) LED, HIGH enables it.
+void HwTools::applyLedDisablePin() {
+    if(ledDisablePin == 0 || ledDisablePin >= 40) return;
+    switch(ledBehaviour) {
+        case LED_BEHAVIOUR_ERROR_ONLY:
+        case LED_BEHAVIOUR_OFF:
+            digitalWrite(ledDisablePin, LOW);
+            break;
+        case LED_BEHAVIOUR_BOOT:
+            digitalWrite(ledDisablePin, bootSuccessful ? LOW : HIGH);
+            break;
+        default:
+            digitalWrite(ledDisablePin, HIGH);
+    }
+}
+
 void HwTools::setBootSuccessful(bool value) {
     if(bootSuccessful && value) return;
     bootSuccessful = value;
-    if(ledDisablePin > 0 && ledDisablePin < 40) {
-        switch(ledBehaviour) {
-            case LED_BEHAVIOUR_ERROR_ONLY:
-            case LED_BEHAVIOUR_OFF:
-                digitalWrite(ledDisablePin, LOW);
-                break;
-            case LED_BEHAVIOUR_BOOT:
-                if(bootSuccessful) {
-                    digitalWrite(ledDisablePin, LOW);
-                } else {
-                    digitalWrite(ledDisablePin, HIGH);
-                }
-                break;
-            default:
-                digitalWrite(ledDisablePin, HIGH);
-        }
-    }
+    applyLedDisablePin();
 }
 
 bool HwTools::ledOn(uint8_t color) {
@@ -596,14 +597,86 @@ bool HwTools::ledOff(uint8_t color) {
     }
 }
 
-bool HwTools::ledBlink(uint8_t color, uint8_t blink) {
-    for(int i = 0; i < blink; i++) {
-        if(!ledOn(color)) return false;
-        delay(75);
-        ledOff(color);
-        if(i != blink) delay(75);
+// Slow timing is used for error codes so flashes are easy to count;
+// fast timing is used for everything else (boot self-test, data-received blip).
+#define LED_FLASH_FAST_ON 80
+#define LED_FLASH_FAST_OFF 160
+#define LED_FLASH_SLOW_ON 250
+#define LED_FLASH_SLOW_OFF 400
+
+bool HwTools::ledColorAvailable(uint8_t color) {
+    if(ledBehaviour == LED_BEHAVIOUR_OFF) return false;
+    if(ledBehaviour == LED_BEHAVIOUR_ERROR_ONLY && color != LED_RED) return false;
+    if(ledBehaviour == LED_BEHAVIOUR_BOOT && color != LED_RED && bootSuccessful) return false;
+    switch(color) {
+        case LED_INTERNAL: return ledPin != 0xFF;
+        case LED_RED: return redPin != 0xFF;
+        case LED_GREEN: return greenPin != 0xFF;
+        case LED_BLUE: return bluePin != 0xFF;
+        case LED_YELLOW: return redPin != 0xFF && greenPin != 0xFF;
+    }
+    return false;
+}
+
+// Arm a non-blocking flash sequence. Ignored if one is already playing, so
+// callers can simply re-arm every loop without resetting an in-progress burst.
+// Returns false (and arms nothing) when the color can't be shown, so callers
+// can fall back to another color.
+bool HwTools::ledFlash(uint8_t color, uint8_t count, bool fast, bool suppressMeterLed) {
+    if(count == 0 || !ledColorAvailable(color)) return false;
+    if(flashLeft > 0) return true;
+    flashColor = color;
+    flashLeft = count;
+    flashOnMs = fast ? LED_FLASH_FAST_ON : LED_FLASH_SLOW_ON;
+    flashOffMs = fast ? LED_FLASH_FAST_OFF : LED_FLASH_SLOW_OFF;
+    flashOn = false;
+    flashAt = 0; // ledLoop lights the first pulse immediately
+    // Force the hardwired meter-activity LED off for the duration of the burst
+    // so it doesn't blink alongside the error code. Restored when the burst ends.
+    flashSuppressHw = suppressMeterLed;
+    if(flashSuppressHw && ledDisablePin > 0 && ledDisablePin < 40) {
+        digitalWrite(ledDisablePin, LOW);
     }
     return true;
+}
+
+// Blocking variant: arm then pump to completion. For boot-time / pre-restart
+// code that runs before loop() is driving ledLoop().
+bool HwTools::ledFlashBlocking(uint8_t color, uint8_t count, bool fast) {
+    bool armed = ledFlash(color, count, fast);
+    while(flashLeft > 0) {
+        ledLoop();
+        delay(5);
+    }
+    return armed;
+}
+
+// Advance the flash state machine. Cheap to call every loop(); does nothing
+// while idle and only touches the pin on a timed transition.
+void HwTools::ledLoop() {
+    if(flashLeft == 0) return;
+    unsigned long now = millis();
+    if(flashOn) {
+        if(now - flashAt < flashOnMs) return;
+        ledOff(flashColor);
+        flashOn = false;
+        flashAt = now;
+        flashLeft--;
+        if(flashLeft == 0 && flashSuppressHw) {
+            applyLedDisablePin(); // restore the meter-activity LED to its normal state
+            flashSuppressHw = false;
+        }
+    } else {
+        if(flashAt != 0 && now - flashAt < flashOffMs) return;
+        if(flashLeft == 0) return;
+        ledOn(flashColor);
+        flashOn = true;
+        flashAt = now;
+    }
+}
+
+bool HwTools::ledBusy() {
+    return flashLeft > 0;
 }
 
 bool HwTools::writeLedPin(uint8_t color, uint8_t state) {

--- a/src/HwTools.h
+++ b/src/HwTools.h
@@ -55,7 +55,10 @@ public:
     int getWifiRssi();
     bool ledOn(uint8_t color);
     bool ledOff(uint8_t color);
-    bool ledBlink(uint8_t color, uint8_t blink);
+    bool ledFlash(uint8_t color, uint8_t count, bool fast = true, bool suppressMeterLed = false);
+    bool ledFlashBlocking(uint8_t color, uint8_t count, bool fast = true);
+    void ledLoop();
+    bool ledBusy();
     void setBootSuccessful(bool value);
     bool isVoltageOptimal(float range = 0.4);
     uint8_t getBoardType();
@@ -64,7 +67,7 @@ public:
 private:
     uint8_t boardType;
     uint8_t ledPin, redPin, greenPin, bluePin, tempPin, atempPin;
-    uint8_t ledDisablePin, ledBehaviour;
+    uint8_t ledDisablePin = 0xFF, ledBehaviour;
     bool ledInvert, rgbInvert;
     uint8_t vccPin, vccGnd_r, vccVcc_r;
     float vccOffset, vccMultiplier;
@@ -85,7 +88,17 @@ private:
 
     bool bootSuccessful = false;
 
+    // Non-blocking flash sequence state (see ledFlash/ledLoop)
+    uint8_t flashColor = 0;
+    uint8_t flashLeft = 0;          // on-phases remaining
+    bool flashOn = false;           // LED currently lit
+    uint16_t flashOnMs = 200, flashOffMs = 350;
+    unsigned long flashAt = 0;      // millis() of last transition
+    bool flashSuppressHw = false;   // hold the meter-activity LED off during this burst
+
     bool writeLedPin(uint8_t color, uint8_t state);
+    void applyLedDisablePin();
+    bool ledColorAvailable(uint8_t color);
     bool isSensorAddressEqual(uint8_t a[8], uint8_t b[8]);
     void getAdcChannel(uint8_t pin, AdcConfig&);
 };


### PR DESCRIPTION
Improves the red error-code LED so customers can reliably distinguish the 1/2/3-flash codes.

- Replaces the blocking `ledBlink()` (delay-based, stalled `loop()`) with a non-blocking `ledFlash()`/`ledLoop()` state machine.
- **Slow, well-spaced flashes for error codes** (250ms on / 400ms off) so 1/2/3 are easy to count; **fast** flashes for everything else (boot self-test, data-received blip) via `ledFlashBlocking()` for the pre-loop boot paths.
- On hardware with an LED-disable GPIO, the hardwired meter-activity LED is forced off for the duration of an error burst, then restored — so error codes aren't visually mixed with meter blinks.

Builds: esp32 + esp8266 pass.