### PR TITLE
Add esp32s2psram dev target with mbedTLS PSRAM override

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -77,6 +77,28 @@ lib_deps = ${esp32.lib_deps}
 lib_ignore = ${common.lib_ignore}
 extra_scripts = ${common.extra_scripts}
 
+# ESP32-S2 with PSRAM (e.g. Wemos S2 Mini, ESP32-S2FNR2 with 2MB PSRAM).
+# Dev-only target — NOT the production Pow-U hardware (which uses S2FH4
+# without PSRAM and must continue using the [env:esp32s2] target).
+# Uses lolin_s2_mini board profile which enables BOARD_HAS_PSRAM and
+# ARDUINO_USB_CDC_ON_BOOT, so Serial output flows over USB-OTG.
+[env:esp32s2psram]
+platform = https://github.com/tasmota/platform-espressif32/releases/download/2023.07.00/platform-espressif32.zip
+framework = arduino
+board = lolin_s2_mini
+board_build.partitions = custom_partition.csv
+build_flags =
+    ${common.build_flags}
+    -D AMS_REMOTE_DEBUG=1
+    -D AMS_CLOUD=1
+    -D AMS_KMP=1
+    -D ZMART_CHARGE=1
+    -L precompiled/esp32s2
+    -lKmpTalker
+lib_deps = ${esp32.lib_deps}
+lib_ignore = ${common.lib_ignore}
+extra_scripts = ${common.extra_scripts}
+
 [env:esp32solo]
 platform = https://github.com/tasmota/platform-espressif32/releases/download/2023.07.00/platform-espressif32.zip
 framework = arduino

--- a/src/AmsToMqttBridge.cpp
+++ b/src/AmsToMqttBridge.cpp
@@ -22,6 +22,10 @@ ADC_MODE(ADC_VCC);
 #include <ESP32SSDP.h>
 #include <esp_task_wdt.h>
 #include <lwip/dns.h>
+#if defined(BOARD_HAS_PSRAM)
+#include <esp_heap_caps.h>
+#include <mbedtls/platform.h>
+#endif
 #endif
 #if defined(AMS_CLOUD)
 #include "CloudConnector.h"
@@ -348,8 +352,30 @@ void resetBootCycleCounter(bool deepSleep) {
 	#endif
 }
 
+#if defined(ESP32) && defined(BOARD_HAS_PSRAM)
+// mbedTLS in Tasmota's libs is built with CONFIG_MBEDTLS_INTERNAL_MEM_ALLOC=1,
+// which forces every TLS allocation into internal SRAM and ignores PSRAM.
+// Override the calloc/free hooks at runtime so the 16 KB SSL record buffers
+// (and BIGNUM workspace during cert verify) land in PSRAM instead.
+// Falls back to internal RAM if PSRAM is exhausted or absent.
+static void *psaware_calloc(size_t n, size_t size) {
+	void *p = heap_caps_calloc(n, size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+	if(!p) p = heap_caps_calloc(n, size, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+	return p;
+}
+static void psaware_free(void *p) {
+	heap_caps_free(p);
+}
+#endif
+
 void setup() {
 	Serial.begin(115200);
+
+	#if defined(ESP32) && defined(BOARD_HAS_PSRAM)
+	if(ESP.getPsramSize() > 0) {
+		mbedtls_platform_set_calloc_free(psaware_calloc, psaware_free);
+	}
+	#endif
 
 	config.hasConfig(); // Need to run this to make sure all configuration have been migrated before we load GPIO config
 


### PR DESCRIPTION
Adds an `esp32s2psram` build env for ESP32-S2 boards with PSRAM, including an mbedTLS PSRAM allocation override. Dev/build target only; not part of the release matrix. Builds clean (and esp32 unaffected).