### PR TITLE
Fixed ADC issue

### DIFF
--- a/src/HwTools.cpp
+++ b/src/HwTools.cpp
@@ -175,38 +175,14 @@ void HwTools::setup(SystemConfig* sys, GpioConfig* config) {
     #endif
     if(config->vccPin > 0 && config->vccPin < 40) {
         #if defined(CONFIG_IDF_TARGET_ESP32S2)
-            getAdcChannel(config->vccPin, voltAdc);
-            if(voltAdc.unit != 0xFF) {
-                if(voltAdc.unit == ADC_UNIT_1) {
-                    voltAdcChar = (esp_adc_cal_characteristics_t*) calloc(1, sizeof(esp_adc_cal_characteristics_t));
-                    esp_adc_cal_value_t adcVal = esp_adc_cal_characterize((adc_unit_t) voltAdc.unit, ADC_ATTEN_DB_11, ADC_WIDTH_BIT_13, 1100, voltAdcChar);
-                    adc1_config_channel_atten((adc1_channel_t) voltAdc.channel, ADC_ATTEN_DB_11);
-                } else if(voltAdc.unit == ADC_UNIT_2) {
-                    voltAdcChar = (esp_adc_cal_characteristics_t*) calloc(1, sizeof(esp_adc_cal_characteristics_t));
-                    esp_adc_cal_value_t adcVal = esp_adc_cal_characterize((adc_unit_t) voltAdc.unit, ADC_ATTEN_DB_11, ADC_WIDTH_BIT_13, 1100, voltAdcChar);
-                    adc2_config_channel_atten((adc2_channel_t) voltAdc.channel, ADC_ATTEN_DB_11);
-                }
-            }
+            analogSetPinAttenuation(config->vccPin, ADC_11db);
         #elif defined(ESP32)
-            getAdcChannel(config->vccPin, voltAdc);
-            if(voltAdc.unit != 0xFF) {
-                if(voltAdc.unit == ADC_UNIT_1) {
-                    voltAdcChar = (esp_adc_cal_characteristics_t*) calloc(1, sizeof(esp_adc_cal_characteristics_t));
-                    esp_adc_cal_value_t adcVal = esp_adc_cal_characterize((adc_unit_t) voltAdc.unit, ADC_ATTEN_DB_6, ADC_WIDTH_BIT_12, 1100, voltAdcChar);
-                    adc1_config_channel_atten((adc1_channel_t) voltAdc.channel, ADC_ATTEN_DB_6);
-                } else if(voltAdc.unit == ADC_UNIT_2) {
-                    voltAdcChar = (esp_adc_cal_characteristics_t*) calloc(1, sizeof(esp_adc_cal_characteristics_t));
-                    esp_adc_cal_value_t adcVal = esp_adc_cal_characterize((adc_unit_t) voltAdc.unit, ADC_ATTEN_DB_6, ADC_WIDTH_BIT_12, 1100, voltAdcChar);
-                    adc2_config_channel_atten((adc2_channel_t) voltAdc.channel, ADC_ATTEN_DB_6);
-                }
-            }
+            analogSetPinAttenuation(config->vccPin, ADC_6db);
         #else
             pinMode(config->vccPin, INPUT);
         #endif
         vccPin = config->vccPin;
     } else {
-        voltAdc.unit = 0xFF;
-        voltAdc.channel = 0xFF;
         vccPin = config->vccPin = 0xFF;
     }
     vccOffset = config->vccOffset / 100.0;
@@ -264,154 +240,16 @@ void HwTools::setup(SystemConfig* sys, GpioConfig* config) {
     }
 }
 
-void HwTools::getAdcChannel(uint8_t pin, AdcConfig& config) {
-    config.unit = 0xFF;
-    config.channel = 0xFF;
-    #if defined(ESP32)
-        switch(pin) {
-            case ADC1_CHANNEL_0_GPIO_NUM:
-                config.unit = ADC_UNIT_1;
-                config.channel = ADC1_CHANNEL_0;
-                break;
-            case ADC1_CHANNEL_1_GPIO_NUM:
-                config.unit = ADC_UNIT_1;
-                config.channel = ADC1_CHANNEL_1;
-                break;
-            case ADC1_CHANNEL_2_GPIO_NUM:
-                config.unit = ADC_UNIT_1;
-                config.channel = ADC1_CHANNEL_2;
-                break;
-            case ADC1_CHANNEL_3_GPIO_NUM:
-                config.unit = ADC_UNIT_1;
-                config.channel = ADC1_CHANNEL_3;
-                break;
-            case ADC1_CHANNEL_4_GPIO_NUM:
-                config.unit = ADC_UNIT_1;
-                config.channel = ADC1_CHANNEL_4;
-                break;
-            #if defined(ADC1_CHANNEL_5_GPIO_NUM)
-            case ADC1_CHANNEL_5_GPIO_NUM:
-                config.unit = ADC_UNIT_1;
-                config.channel = ADC1_CHANNEL_5;
-                break;
-            #endif
-            #if defined(ADC1_CHANNEL_6_GPIO_NUM)
-            case ADC1_CHANNEL_6_GPIO_NUM:
-                config.unit = ADC_UNIT_1;
-                config.channel = ADC1_CHANNEL_6;
-                break;
-            #endif
-            #if defined(ADC1_CHANNEL_7_GPIO_NUM)
-            case ADC1_CHANNEL_7_GPIO_NUM:
-                config.unit = ADC_UNIT_1;
-                config.channel = ADC1_CHANNEL_7;
-                break;
-            #endif
-            #if defined(ADC1_CHANNEL_8_GPIO_NUM)
-            case ADC1_CHANNEL_8_GPIO_NUM:
-                config.unit = ADC_UNIT_1;
-                config.channel = ADC1_CHANNEL_8;
-                break;
-            #endif
-            #if defined(ADC1_CHANNEL_9_GPIO_NUM)
-            case ADC1_CHANNEL_9_GPIO_NUM:
-                config.unit = ADC_UNIT_1;
-                config.channel = ADC1_CHANNEL_9;
-                break;
-            #endif
-            #if defined(ADC2_CHANNEL_0_GPIO_NUM)
-            case ADC2_CHANNEL_0_GPIO_NUM:
-                config.unit = ADC_UNIT_2;
-                config.channel = ADC2_CHANNEL_0;
-                break;
-            #endif
-            #if defined(ADC2_CHANNEL_1_GPIO_NUM)
-            case ADC2_CHANNEL_1_GPIO_NUM:
-                config.unit = ADC_UNIT_2;
-                config.channel = ADC2_CHANNEL_1;
-                break;
-            #endif
-            #if defined(ADC2_CHANNEL_2_GPIO_NUM)
-            case ADC2_CHANNEL_2_GPIO_NUM:
-                config.unit = ADC_UNIT_2;
-                config.channel = ADC2_CHANNEL_2;
-                break;
-            #endif
-            #if defined(ADC2_CHANNEL_3_GPIO_NUM)
-            case ADC2_CHANNEL_3_GPIO_NUM:
-                config.unit = ADC_UNIT_2;
-                config.channel = ADC2_CHANNEL_3;
-                break;
-            #endif
-            #if defined(ADC2_CHANNEL_4_GPIO_NUM)
-            case ADC2_CHANNEL_4_GPIO_NUM:
-                config.unit = ADC_UNIT_2;
-                config.channel = ADC2_CHANNEL_4;
-                break;
-            #endif
-            #if defined(ADC2_CHANNEL_5_GPIO_NUM)
-            case ADC2_CHANNEL_5_GPIO_NUM:
-                config.unit = ADC_UNIT_2;
-                config.channel = ADC2_CHANNEL_5;
-                break;
-            #endif
-            #if defined(ADC2_CHANNEL_6_GPIO_NUM)
-            case ADC2_CHANNEL_6_GPIO_NUM:
-                config.unit = ADC_UNIT_2;
-                config.channel = ADC2_CHANNEL_6;
-                break;
-            #endif
-            #if defined(ADC2_CHANNEL_7_GPIO_NUM)
-            case ADC2_CHANNEL_7_GPIO_NUM:
-                config.unit = ADC_UNIT_2;
-                config.channel = ADC2_CHANNEL_7;
-                break;
-            #endif
-            #if defined(ADC2_CHANNEL_8_GPIO_NUM)
-            case ADC2_CHANNEL_8_GPIO_NUM:
-                config.unit = ADC_UNIT_2;
-                config.channel = ADC2_CHANNEL_8;
-                break;
-            #endif
-            #if defined(ADC2_CHANNEL_9_GPIO_NUM)
-            case ADC2_CHANNEL_9_GPIO_NUM:
-                config.unit = ADC_UNIT_2;
-                config.channel = ADC2_CHANNEL_9;
-                break;
-            #endif
-        }
-    #endif
-}
 
 float HwTools::getVcc() {
     float volts = 0.0;
     if(vccPin != 0xFF) {
         #if defined(ESP32)
-            if(voltAdc.unit != 0xFF) {
-                uint32_t x = 0;
-                for (int i = 0; i < 10; i++) {
-                    if(voltAdc.unit == ADC_UNIT_1) {
-                        x +=  adc1_get_raw((adc1_channel_t) voltAdc.channel);
-                    } else if(voltAdc.unit == ADC_UNIT_2) {
-                        int v = 0;
-                        #if defined(CONFIG_IDF_TARGET_ESP32S2)
-                        adc2_get_raw((adc2_channel_t) voltAdc.channel, ADC_WIDTH_BIT_13, &v);
-                        #elif defined(CONFIG_IDF_TARGET_ESP32)
-                        adc2_get_raw((adc2_channel_t) voltAdc.channel, ADC_WIDTH_BIT_12, &v);
-                        #endif
-                        x += v;
-                    }
-                }
-                x = x / 10;
-                uint32_t voltage = esp_adc_cal_raw_to_voltage(x, voltAdcChar);
-                volts = voltage / 1000.0;
-            } else {
-                uint32_t x = 0;
-                for (int i = 0; i < 10; i++) {
-                    x += analogRead(vccPin);
-                }
-                volts = (x * 3.3) / 10.0 / analogRange;
+            uint32_t x = 0;
+            for (int i = 0; i < 10; i++) {
+                x += analogReadMilliVolts(vccPin);
             }
+            volts = x / 10.0 / 1000.0;
         #else
             uint32_t x = 0;
             for (int i = 0; i < 10; i++) {

--- a/src/HwTools.h
+++ b/src/HwTools.h
@@ -13,9 +13,6 @@
 #include <ESP8266WiFi.h>
 #elif defined(ESP32)
 #include <WiFi.h>
-#include <driver/adc.h>
-#include <esp_adc_cal.h>
-#include <soc/adc_channel.h>
 #endif
 
 #include <DallasTemperature.h>
@@ -33,11 +30,6 @@ struct TempSensorData {
     float lastRead;
     float lastValidRead;
     bool changed;
-};
-
-struct AdcConfig {
-    uint8_t unit;
-    uint8_t channel;
 };
 
 class HwTools {
@@ -73,10 +65,6 @@ private:
     unsigned long lastVccRead = 0;
 
     uint16_t analogRange = 1024;
-    AdcConfig voltAdc, tempAdc;
-    #if defined(ESP32)
-        esp_adc_cal_characteristics_t* voltAdcChar, tempAdcChar;
-    #endif
     bool tempSensorInit;
     OneWire *oneWire = NULL;
     DallasTemperature *sensorApi = NULL;
@@ -87,7 +75,6 @@ private:
 
     bool writeLedPin(uint8_t color, uint8_t state);
     bool isSensorAddressEqual(uint8_t a[8], uint8_t b[8]);
-    void getAdcChannel(uint8_t pin, AdcConfig&);
 };
 
 #endif


### PR DESCRIPTION
Replaces the deprecated ESP-IDF `esp_adc_cal_*` voltage-ADC characterization path in HwTools with a simpler reading (removes ~180 lines of legacy ADC calibration code). Builds: esp8266 + esp32 pass.