### PR TITLE
Add compile-time custom MQTT connector via custom/ overlay

### DIFF
--- a/custom-example/config.h
+++ b/custom-example/config.h
@@ -16,3 +16,35 @@
 
 // Default UI language tag (must match a key in the translation files)
 //#define DEFAULT_LANGUAGE "en"
+
+
+// ---------------------------------------------------------------------------
+// Custom MQTT connector
+//
+// When enabled, the firmware runs a second MQTT connector in parallel with
+// the user-configurable broker (the one set via the web UI).  The custom
+// connector is driven entirely by the macros below — it does not read from
+// EEPROM and cannot be changed at runtime.
+//
+// To enable: uncomment CUSTOM_MQTT_HOST and any other fields you need to
+// override.  Anything left commented falls back to the defaults shown.
+//
+// Supported payload formats: 0 / 5 / 6 (JSON variants), 1 / 2 (raw).
+// Domoticz (3), Home Assistant (4) and Passthrough (255) are intentionally
+// not supported here because they depend on additional runtime config that
+// belongs to the user-facing broker slot.
+// ---------------------------------------------------------------------------
+
+//#define CUSTOM_MQTT_HOST "mqtt.example.com"
+//#define CUSTOM_MQTT_PORT 1883
+//#define CUSTOM_MQTT_USERNAME ""
+//#define CUSTOM_MQTT_PASSWORD ""
+//#define CUSTOM_MQTT_PUBLISH_TOPIC "ams"
+//#define CUSTOM_MQTT_SUBSCRIBE_TOPIC ""   // empty -> "<publish-topic>/command"
+//#define CUSTOM_MQTT_PAYLOAD_FORMAT 0     // 0 JSON, 1/2 raw, 5/6 JSON variants
+//#define CUSTOM_MQTT_SSL false            // true requires CUSTOM_MQTT_PORT 8883 (typically)
+//#define CUSTOM_MQTT_CA_VERIFY false      // true requires a CA cert provisioned via the normal flow
+//#define CUSTOM_MQTT_KEEPALIVE 60         // seconds
+//#define CUSTOM_MQTT_TIMEOUT 1000         // milliseconds
+//#define CUSTOM_MQTT_STATE_UPDATE false   // periodic state publish
+//#define CUSTOM_MQTT_STATE_UPDATE_INTERVAL 10  // seconds

--- a/scripts/generate_includes.py
+++ b/scripts/generate_includes.py
@@ -6,10 +6,12 @@ Asset sources (in priority order — custom/ overrides defaults):
   UI dist:         custom/ui/dist/   or  ui/dist/
   Webserver JSON:  custom/ui/json/   or  src/webserver/json/
   MQTT JSON:       src/mqtt/json/
+  Custom defines:  custom/config.h   (optional — empty header if missing)
 
 Generated headers:
   src/webserver/html/*.h   — gzip-compressed UI JS/CSS; raw others
   src/mqtt/json/*.h        — MQTT handler JSON templates (raw string literals)
+  src/CustomDefaults.h     — wrapper that includes custom/config.h when present
 """
 
 import os
@@ -139,7 +141,20 @@ else:
     print(f"WARN: UI dist not found at '{ui_dist}' — skipping UI header generation. Run 'npm run build' in ui/")
 
 # ---------------------------------------------------------------------------
-# 2. MQTT handler JSON templates (raw string literals, no compression)
+# 2. CustomDefaults.h — bridge for the custom/ overlay's config.h
+# ---------------------------------------------------------------------------
+
+custom_defaults_out = "src/CustomDefaults.h"
+custom_config_src   = "custom/config.h"
+with open(custom_defaults_out, "w") as f:
+    f.write("#ifndef _CUSTOMDEFAULTS_H\n")
+    f.write("#define _CUSTOMDEFAULTS_H\n")
+    if os.path.exists(custom_config_src):
+        f.write('#include "../custom/config.h"\n')
+    f.write("#endif\n")
+
+# ---------------------------------------------------------------------------
+# 3. MQTT handler JSON templates (raw string literals, no compression)
 # ---------------------------------------------------------------------------
 
 mqtt_json_src = "src/mqtt/json"

--- a/src/AmsToMqttBridge.cpp
+++ b/src/AmsToMqttBridge.cpp
@@ -87,6 +87,8 @@ ADC_MODE(ADC_VCC);
 #include "HomeAssistantMqttHandler.h"
 #include "PassthroughMqttHandler.h"
 
+#include "CustomDefaults.h"
+
 #include "MeterCommunicator.h"
 #include "PassiveMeterCommunicator.h"
 #if defined(AMS_KMP)
@@ -169,6 +171,63 @@ MqttConfig energySpeedometerConfig = {
 };
 #endif
 
+#if defined(CUSTOM_MQTT_HOST)
+#ifndef CUSTOM_MQTT_PORT
+#define CUSTOM_MQTT_PORT 1883
+#endif
+#ifndef CUSTOM_MQTT_USERNAME
+#define CUSTOM_MQTT_USERNAME ""
+#endif
+#ifndef CUSTOM_MQTT_PASSWORD
+#define CUSTOM_MQTT_PASSWORD ""
+#endif
+#ifndef CUSTOM_MQTT_PUBLISH_TOPIC
+#define CUSTOM_MQTT_PUBLISH_TOPIC "ams"
+#endif
+#ifndef CUSTOM_MQTT_SUBSCRIBE_TOPIC
+#define CUSTOM_MQTT_SUBSCRIBE_TOPIC ""
+#endif
+#ifndef CUSTOM_MQTT_PAYLOAD_FORMAT
+#define CUSTOM_MQTT_PAYLOAD_FORMAT 0
+#endif
+#ifndef CUSTOM_MQTT_SSL
+#define CUSTOM_MQTT_SSL false
+#endif
+#ifndef CUSTOM_MQTT_CA_VERIFY
+#define CUSTOM_MQTT_CA_VERIFY false
+#endif
+#ifndef CUSTOM_MQTT_KEEPALIVE
+#define CUSTOM_MQTT_KEEPALIVE 60
+#endif
+#ifndef CUSTOM_MQTT_TIMEOUT
+#define CUSTOM_MQTT_TIMEOUT 1000
+#endif
+#ifndef CUSTOM_MQTT_STATE_UPDATE
+#define CUSTOM_MQTT_STATE_UPDATE false
+#endif
+#ifndef CUSTOM_MQTT_STATE_UPDATE_INTERVAL
+#define CUSTOM_MQTT_STATE_UPDATE_INTERVAL 10
+#endif
+AmsMqttHandler* customMqttHandler = NULL;
+MqttConfig customMqttConfig = {
+	CUSTOM_MQTT_HOST,
+	CUSTOM_MQTT_PORT,
+	"",  // clientId — filled at runtime from chip-derived unique name
+	CUSTOM_MQTT_PUBLISH_TOPIC,
+	CUSTOM_MQTT_SUBSCRIBE_TOPIC,
+	CUSTOM_MQTT_USERNAME,
+	CUSTOM_MQTT_PASSWORD,
+	CUSTOM_MQTT_PAYLOAD_FORMAT,
+	CUSTOM_MQTT_SSL,
+	0,                                       // magic
+	CUSTOM_MQTT_STATE_UPDATE,
+	CUSTOM_MQTT_STATE_UPDATE_INTERVAL,
+	CUSTOM_MQTT_TIMEOUT,
+	CUSTOM_MQTT_KEEPALIVE,
+	0                                        // rebootMinutes — managed by primary handler only
+};
+#endif
+
 Stream *hanSerial;
 HardwareSerial *hwSerial = NULL;
 uint8_t rxBufferErrors = 0;
@@ -238,6 +297,9 @@ void handleMdns();
 #endif
 #if defined(ESP32) && defined(ENERGY_SPEEDOMETER_PASS)
 void handleEnergySpeedometer();
+#endif
+#if defined(CUSTOM_MQTT_HOST)
+void handleCustomMqtt();
 #endif
 #if defined(AMS_CLOUD)
 void handleCloud();
@@ -677,6 +739,11 @@ void loop() {
 				if(mqttHandler != NULL) {
 					mqttHandler->disconnect();
 				}
+				#if defined(CUSTOM_MQTT_HOST)
+				if(customMqttHandler != NULL) {
+					customMqttHandler->disconnect();
+				}
+				#endif
 			}
 			networkConnected = false;
 			connectToNetwork();
@@ -695,6 +762,9 @@ void loop() {
 					#if defined(ENERGY_SPEEDOMETER_PASS)
 						handleEnergySpeedometer();
 					#endif
+				#endif
+				#if defined(CUSTOM_MQTT_HOST)
+					handleCustomMqtt();
 				#endif
 
 				// In case of BUS powered meters, we need to be sure voltage is stable before fetching prices. But we refuse to wait forever, so max 30 seconds
@@ -841,7 +911,11 @@ void handleUpdater() {
 		updater.ackUpgradeInformationChanged();
 		if(mqttHandler != NULL)
 			mqttHandler->publishFirmware();
-		
+		#if defined(CUSTOM_MQTT_HOST)
+		if(customMqttHandler != NULL)
+			customMqttHandler->publishFirmware();
+		#endif
+
 		if(upinfo.errorCode == AMS_UPDATE_ERR_SUCCESS_SIGNAL) {
 			debugW_P(PSTR("Rebooting to firmware version %s"), upinfo.toVersion);
 			upinfo.errorCode == AMS_UPDATE_ERR_SUCCESS_CONFIRMED;
@@ -927,6 +1001,37 @@ void handleEnergySpeedometer() {
 			energySpeedometer = NULL;
 		}
 	}
+}
+#endif
+
+#if defined(CUSTOM_MQTT_HOST)
+void handleCustomMqtt() {
+	if(meterState.getMeterId().isEmpty()) return;
+	if(customMqttHandler == NULL) {
+		config.getUniqueName(customMqttConfig.clientId, 32);
+		switch(CUSTOM_MQTT_PAYLOAD_FORMAT) {
+			case 1:
+			case 2:
+				customMqttHandler = new RawMqttHandler(customMqttConfig, &Debug, (char*) commonBuffer, &updater);
+				break;
+			default:
+				customMqttHandler = new JsonMqttHandler(customMqttConfig, &Debug, (char*) commonBuffer, &hw, &ds, &updater);
+				break;
+		}
+		customMqttHandler->setCaVerification(CUSTOM_MQTT_CA_VERIFY);
+	}
+	if(!customMqttHandler->connected()) {
+		lwmqtt_err_t err = customMqttHandler->lastError();
+		if(err > 0)
+			debugE_P(PSTR("Custom MQTT connector reporting error (%d)"), err);
+		customMqttHandler->connect();
+		customMqttHandler->publishSystem(&hw, ps, &ea);
+		if(ps != NULL && ps->hasPrice()) {
+			customMqttHandler->publishPrices(ps);
+		}
+	}
+	customMqttHandler->loop();
+	delay(10);
 }
 #endif
 
@@ -1221,6 +1326,12 @@ void handleSystem(unsigned long now) {
 				energySpeedometer->publishSystem(&hw, ps, &ea);
 			}
 			#endif
+			#if defined(CUSTOM_MQTT_HOST)
+			if(customMqttHandler != NULL) {
+				customMqttHandler->publishSystem(&hw, ps, &ea);
+				customMqttHandler->publishFirmware();
+			}
+			#endif
 		}
 		lastSysupdate = now;
 		end = millis();
@@ -1250,6 +1361,11 @@ void handleTemperature(unsigned long now) {
 			if(mqttHandler != NULL && WiFi.getMode() == WIFI_STA && WiFi.status() == WL_CONNECTED) {
 				mqttHandler->publishTemperatures(&config, &hw);
 			}
+			#if defined(CUSTOM_MQTT_HOST)
+			if(customMqttHandler != NULL && WiFi.getMode() == WIFI_STA && WiFi.status() == WL_CONNECTED) {
+				customMqttHandler->publishTemperatures(&config, &hw);
+			}
+			#endif
 		}
 		end = millis();
 		if(end - start > SLOW_PROC_TRIGGER_MS) {
@@ -1263,14 +1379,21 @@ void handlePriceService(unsigned long now) {
 		unsigned long start, end;
 		if(ps != NULL && ntpEnabled) {
 			start = millis();
-			if(ps->loop() && mqttHandler != NULL) {
+			if(ps->loop()) {
 				end = millis();
 				if(end - start > SLOW_PROC_TRIGGER_MS) {
 					debugW_P(PSTR("Used %dms to update prices"), end-start);
 				}
-	
+
 				start = millis();
-				mqttHandler->publishPrices(ps);
+				if(mqttHandler != NULL) {
+					mqttHandler->publishPrices(ps);
+				}
+				#if defined(CUSTOM_MQTT_HOST)
+				if(customMqttHandler != NULL) {
+					customMqttHandler->publishPrices(ps);
+				}
+				#endif
 				end = millis();
 				if(end - start > SLOW_PROC_TRIGGER_MS) {
 					debugW_P(PSTR("Used %dms to publish prices to MQTT"), end-start);
@@ -1557,6 +1680,11 @@ void handleDataSuccess(AmsData* data) {
 	#if defined(ESP32) && defined(ENERGY_SPEEDOMETER_PASS)
 	if(energySpeedometer != NULL && checkVoltageIfNeeded(0.1)) {
 		energySpeedometer->publish(&meterState, &meterState, &ea, ps);
+	}
+	#endif
+	#if defined(CUSTOM_MQTT_HOST)
+	if(customMqttHandler != NULL && checkVoltageIfNeeded(0.1)) {
+		customMqttHandler->publish(data, &meterState, &ea, ps);
 	}
 	#endif
 


### PR DESCRIPTION
Adds an optional compile-time custom MQTT connector, enabled via the `custom/` overlay (`CUSTOM_MQTT_*` defines in `custom/config.h`; see `custom-example/config.h`). When the overlay isn't present the build is unchanged.

- `custom-example/config.h`: documents the `CUSTOM_MQTT_*` options.
- `scripts/generate_includes.py`: surfaces the defines into `CustomDefaults.h`.
- `AmsToMqttBridge.cpp`: wires the second/custom MQTT connector behind the defines.

Builds: esp8266 + esp32 pass (default, overlay absent).