### PR TITLE
Guard GCM system-title length to prevent plaintext-DSMR reboot loop

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -161,6 +161,9 @@ build_flags =
     -I src
     -I test/stubs
     -std=c++17
+    -fsanitize=address
+    -fno-omit-frame-pointer
+build_type = debug
 test_framework = unity
 test_filter = test_decoder
 test_build_src = yes

--- a/src/decoder/src/GcmParser.cpp
+++ b/src/decoder/src/GcmParser.cpp
@@ -42,6 +42,13 @@ int8_t GCMParser::parse(uint8_t *d, DataParserContext &ctx, bool hastag) {
     ptr++;
     headersize++;
 
+    // The system title is at most 8 bytes (DLMS). A larger value means this is
+    // not a GCM frame at all — e.g. a plaintext DSMR telegram routed here only
+    // because an encryption key is configured. Reject it before the memcpy
+    // below overflows ctx.system_title[8] / initialization_vector[12] and
+    // crashes the device in a reboot loop.
+    if(systemTitleLength > 8) return GCM_DECRYPT_FAILED;
+
     uint8_t initialization_vector[12];
     memset(ctx.system_title, 0, 8);
     memset(initialization_vector, 0, 12);

--- a/test/test_decoder/test_main.cpp
+++ b/test/test_decoder/test_main.cpp
@@ -14,6 +14,16 @@
 void setUp(void) {}
 void tearDown(void) {}
 
+#if defined(__SANITIZE_ADDRESS__)
+// The decode path deletes AmsData subclasses (IEC6205675 etc.) through the base
+// pointer, which trips ASAN's new-delete-type-mismatch check. That is benign on
+// the target platforms and unrelated to what these tests guard. Suppress only
+// that class so ASAN stays focused on memory-safety regressions (overflows).
+// detect_leaks=0: the tests intentionally leak throwaway AmsData/buffers; we
+// want ASAN here for buffer-overflow detection, not leak accounting.
+extern "C" const char* __asan_default_options() { return "new_delete_type_mismatch=0:detect_leaks=0"; }
+#endif
+
 // ---------------------------------------------------------------------------
 // Low-level parser guards
 // ---------------------------------------------------------------------------
@@ -63,6 +73,8 @@ void test_encrypted_landisgyr_501(void);
 void test_encrypted_kaifa_905(void);
 void test_encrypted_kamstrup_73(void);
 void test_encrypted_framing_no_key(void);
+// defined in test_plaintext_with_key.cpp
+void test_plaintext_dsmr_with_key_does_not_overflow(void);
 
 int main(int argc, char** argv) {
     if (argc > 1 && strcmp(argv[1], "gen") == 0) {
@@ -84,5 +96,6 @@ int main(int argc, char** argv) {
     RUN_TEST(test_encrypted_kaifa_905);
     RUN_TEST(test_encrypted_kamstrup_73);
     RUN_TEST(test_encrypted_framing_no_key);
+    RUN_TEST(test_plaintext_dsmr_with_key_does_not_overflow);
     return UNITY_END();
 }

--- a/test/test_decoder/test_plaintext_with_key.cpp
+++ b/test/test_decoder/test_plaintext_with_key.cpp
@@ -1,0 +1,59 @@
+/**
+ * @copyright Utilitech AS 2023-2026
+ * License: Fair Source
+ *
+ * Regression for the "POW-P1 rebooter og har max oppetid på 10 sek" report
+ * (Kamstrup OMNIA / KAM5, Denmark, June 2026).
+ *
+ * The meter sends a *plaintext* DSMR/P1 telegram, but the user had an
+ * encryption key configured. With a key set, DSMRParser routes the telegram
+ * to GCMParser, which read the first cleartext byte ('0' == 0x30 == 48) as the
+ * system-title length and memcpy'd 48 bytes into the 8-byte ctx.system_title
+ * and 12-byte initialization_vector — a stack buffer overflow that rebooted the
+ * device in a loop (reboot reason "Software reset (3/0)").
+ *
+ * Expected safe behaviour: the GCM layer rejects the frame cleanly (no
+ * overflow), unwrap fails, and the decode returns NULL. With AddressSanitizer
+ * on the native env, the pre-fix overflow aborts the test instead of passing.
+ */
+#include <unity.h>
+#include <string.h>
+#include "AmsData.h"
+#include "decoder_harness.h"
+
+// The exact cleartext KAM5 telegram from the report. Header line "/KAM5",
+// blank line, then OBIS body starting with the digit '0' — that leading byte
+// is what GCMParser misread as a 48-byte system title.
+static const char KAM5_PLAINTEXT[] =
+    "/KAM5\r\n"
+    "\r\n"
+    "0-0:1.0.0(260611195950S)\r\n"
+    "1-0:1.8.0(00000215.616*kWh)\r\n"
+    "1-0:2.8.0(00000000.000*kWh)\r\n"
+    "1-0:3.8.0(00000000.145*kVArh)\r\n"
+    "1-0:4.8.0(00000059.680*kVArh)\r\n"
+    "1-0:1.7.0(0000.702*kW)\r\n"
+    "1-0:2.7.0(0000.000*kW)\r\n"
+    "1-0:32.7.0(228.1*V)\r\n"
+    "1-0:52.7.0(228.3*V)\r\n"
+    "1-0:72.7.0(229.1*V)\r\n"
+    "!A906\r\n";
+
+void test_plaintext_dsmr_with_key_does_not_overflow(void) {
+    // A non-zero encryption key makes the firmware build a GCMParser and treat
+    // the DSMR telegram as encrypted — the exact precondition for the crash.
+    uint8_t key[16];
+    memset(key, 0xAB, sizeof(key));
+
+    static uint8_t buf[1024];
+    uint16_t len = (uint16_t)(sizeof(KAM5_PLAINTEXT) - 1);
+    memcpy(buf, KAM5_PLAINTEXT, len);
+
+    MeterConfig cfg;
+    memset(&cfg, 0, sizeof(cfg));
+
+    // Must not overflow/crash. A plaintext frame can't be decrypted, so the
+    // safe outcome is a clean rejection (NULL), not a reboot.
+    AmsData* d = harness_decode(buf, len, &cfg, key, NULL);
+    TEST_ASSERT_NULL_MESSAGE(d, "plaintext DSMR with key set should be rejected, not decoded");
+}


### PR DESCRIPTION
## Problem

Customer report (Kamstrup OMNIA / `KAM5`, Denmark, June 2026): **POW-P1 reboots constantly, up max ~10 s**. Telnet debug showed `DSMR wants to decrypt … length: 684` → `Failed! (-51)`, reboot reason **`Software reset (3/0)`**. Disabling encryption was the workaround.

The meter sends a **plaintext** DSMR/P1 telegram, but the user had an **encryption key configured**. With a key set, `DSMRParser` routes the telegram to `GCMParser` (`DsmrParser.cpp:33`). There, the first cleartext byte — `'0'` (`0x30` == **48**) — is read as the system-title length:

```cpp
uint8_t systemTitleLength = *ptr;            // 48
...
memcpy(ctx.system_title, ptr, systemTitleLength);          // 48 bytes → uint8_t[8]
memcpy(initialization_vector, ctx.system_title, systemTitleLength); // 48 bytes → uint8_t[12]
```

`ctx.system_title` is `uint8_t[8]` and `initialization_vector` is `uint8_t[12]` → **stack buffer overflow → reboot loop**.

Still present on `main`: the #1206 hardening guarded the *ciphertext* length (`len < 17`, `len < authkeylen+5`) but **not** the system-title length, and the overflowing `memcpy` runs before the `len + headersize > ctx.length` guard.

## Fix

Reject system titles longer than 8 bytes (the DLMS maximum) before the `memcpy`. A plaintext frame is then cleanly rejected with `GCM_DECRYPT_FAILED`, which `PassiveMeterCommunicator` already handles gracefully — no crash.

```cpp
if(systemTitleLength > 8) return GCM_DECRYPT_FAILED;
```

## Tests

- New native regression test `test_plaintext_dsmr_with_key_does_not_overflow` feeds the reported plaintext `/KAM5` telegram to a key-configured decoder and asserts a clean rejection.
- Enabled **AddressSanitizer** on the `[env:native]` test env so this class of overflow fails the suite deterministically. Verified the test is **red pre-fix** (`stack-buffer-overflow … WRITE of size 48 at GcmParser.cpp:49`) and **green post-fix**. All 15 decoder tests pass.

Two ASAN default-options are baked into the test binary (`new_delete_type_mismatch=0`, `detect_leaks=0`) to silence pre-existing, benign harness noise unrelated to memory-safety overflows.

## Why this is hard to detect, and why the guard is safe

On the DSMR/P1 path there is **no in-band marker for encryption**. Frames are dispatched purely by first byte (`PassiveMeterCommunicator.cpp:338`): `0xDB` → GCM frame (tag present), `/` (`0x2F`) → DSMR. An *encrypted* DSMR meter sends a plaintext `/…` identification line followed by a **bare GCM APDU with no `0xDB` tag** (we call `GCMParser::parse(…, hastag=false)`). So the body of an encrypted telegram and the body of a plaintext one are byte-for-byte indistinguishable without attempting decryption — the firmware's only signal is whether a key is configured. This bug is that assumption meeting a plaintext meter.

The known real-world no-`0xDB` encrypted-DSMR format is the **Elgama GAMA** (Poland, Stoen/E.ON): [#1177](https://github.com/UtilitechAS/amsreader-firmware/issues/1177) (GAMA 150 G15, decrypts successfully) and [#1198](https://github.com/UtilitechAS/amsreader-firmware/issues/1198) (GAMA 350 G35). #1177's encrypted payload begins `00 82 02 06 30 …` → **`systemTitleLength = 0x00`** (this meter sends no system title). The `> 8` guard leaves that untouched, while a plaintext telegram's first post-header byte is always an OBIS digit (`0x30`–`0x39` = 48–57, all `> 8`) and is rejected. So the boundary correctly accepts the real encrypted case and rejects plaintext. (We hold no Elgama key, so it isn't in the decoder test corpus.)

## Notes / out of scope
- The thread also mentions the meter's model/serial not being recognized — expected: the `/KAM5` plaintext header carries no model/ID. No decoder change.
- "Entering keys enabled power on the P1 port" is meter/hardware-side, not firmware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
