### PR TITLE
Skip GCM auth on ESP8266 when no auth key is set (align with ESP32)

### DIFF
--- a/src/decoder/src/GcmParser.cpp
+++ b/src/decoder/src/GcmParser.cpp
@@ -132,7 +132,10 @@ int8_t GCMParser::parse(uint8_t *d, DataParserContext &ctx, bool hastag) {
         }
         br_gcm_flip(&gcmCtx);
         br_gcm_run(&gcmCtx, 0, (void*) (ptr), len - authkeylen - 5); // 5 == security tag and frame counter
-        if(authkeylen > 0 && br_gcm_check_tag_trunc(&gcmCtx, authentication_tag, authkeylen) != 1) {
+        // Only enforce the tag when an authentication key is configured, matching the
+        // ESP32/native paths. With a blank AK we decrypt without verifying integrity,
+        // which lets meters that don't use standard SC+AK authentication be read.
+        if(authenticate && br_gcm_check_tag_trunc(&gcmCtx, authentication_tag, authkeylen) != 1) {
             return GCM_AUTH_FAILED;
         }
     #elif defined(ESP32)

--- a/test/test_decoder/test_encrypted.cpp
+++ b/test/test_decoder/test_encrypted.cpp
@@ -179,3 +179,40 @@ void test_encrypted_framing_no_key(void) {
     TEST_ASSERT_EQUAL_MESSAGE(0, missing_title, "frame reached GCM but extracted no system title");
     TEST_ASSERT_GREATER_THAN_MESSAGE(0, reached, "no encrypted frame reached the GCM layer");
 }
+
+// Decoding an authenticated frame (one issued with an AK) using only the encryption
+// key — AK omitted — must still decode: a blank authentication key skips GCM tag
+// verification rather than failing. This locks the cross-platform contract that the
+// ESP8266 BearSSL path now matches (the ESP32/native mbedTLS paths already behaved
+// this way). Exercises the native mbedTLS path; the ESP8266 br_gcm path is identical
+// in intent but only compiles on-device.
+void test_encrypted_decode_without_authkey(void) {
+#if !defined(HAVE_MBEDTLS)
+    TEST_IGNORE_MESSAGE("native mbedTLS not available (install libmbedtls-dev) — skipping");
+#else
+    int tested = 0, failures = 0;
+    for (size_t i = 0; i < COUNT(ENC_KEYED); i++) {
+        const KeyedFixture& k = ENC_KEYED[i];
+        if (k.ak_secret == nullptr) continue;          // only authenticated fixtures are meaningful here
+        uint8_t ek[16];
+        if (!load_key(k.ek_secret, ek)) continue;      // need the encryption key
+
+        static uint8_t buf[4096];
+        int len = harness_load_fixture(k.path, buf, sizeof(buf));
+        if (len <= 0) { printf("  load FAIL %s\n", k.path); failures++; continue; }
+        MeterConfig cfg; memset(&cfg, 0, sizeof(cfg));
+        // EK only, AK deliberately omitted -> auth must be skipped, frame still decodes
+        AmsData* d = harness_decode(buf, (uint16_t)len, &cfg, ek, NULL);
+        tested++;
+        if (!d || d->getListType() < 1) { printf("  DECODE FAIL (no-AK) %s\n", k.path); failures++; }
+        if (d) delete d;
+    }
+    if (tested == 0) {
+        TEST_IGNORE_MESSAGE("no authenticated fixtures with keys available");
+    } else {
+        char msg[96];
+        snprintf(msg, sizeof(msg), "%d/%d authenticated fixtures failed to decode with AK omitted", failures, tested);
+        TEST_ASSERT_EQUAL_MESSAGE(0, failures, msg);
+    }
+#endif
+}

--- a/test/test_decoder/test_main.cpp
+++ b/test/test_decoder/test_main.cpp
@@ -73,6 +73,7 @@ void test_encrypted_landisgyr_501(void);
 void test_encrypted_kaifa_905(void);
 void test_encrypted_kamstrup_73(void);
 void test_encrypted_framing_no_key(void);
+void test_encrypted_decode_without_authkey(void);
 // defined in test_plaintext_with_key.cpp
 void test_plaintext_dsmr_with_key_does_not_overflow(void);
 
@@ -96,6 +97,7 @@ int main(int argc, char** argv) {
     RUN_TEST(test_encrypted_kaifa_905);
     RUN_TEST(test_encrypted_kamstrup_73);
     RUN_TEST(test_encrypted_framing_no_key);
+    RUN_TEST(test_encrypted_decode_without_authkey);
     RUN_TEST(test_plaintext_dsmr_with_key_does_not_overflow);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary

Aligns the ESP8266 GCM path with ESP32/native: when **no authentication key is configured**, decrypt without verifying the GCM tag instead of failing.

## Background

The ESP8266 (BearSSL) path enforced the GCM tag whenever the frame's security byte requested authentication, regardless of whether an AK was configured — it gated the tag check on `authkeylen > 0`. The ESP32 and native (mbedTLS) paths instead gate on `authenticate`, which is true only when the AK has a non-zero byte. So a blank AK already meant "decrypt without auth" on ESP32, but **failed with `-51` on ESP8266**.

## Change

One-line alignment in `GcmParser.cpp` (ESP8266 branch):

```diff
-        if(authkeylen > 0 && br_gcm_check_tag_trunc(&gcmCtx, authentication_tag, authkeylen) != 1) {
+        if(authenticate && br_gcm_check_tag_trunc(&gcmCtx, authentication_tag, authkeylen) != 1) {
             return GCM_AUTH_FAILED;
         }
```

- Meters configured **with** an auth key: unchanged — the tag is still verified.
- Meters configured **without** an auth key: the frame is decrypted with the encryption key alone and the tag is not checked (no integrity guarantee — opt-in by leaving the AK blank), matching ESP32.

## Why

Some meters use a non-standard authentication scheme that doesn't verify against the DLMS `SC ‖ AK` AAD, so they can only be read with the encryption key. The Polish **Stoen / Elgama GAMA 350** (#1198) is one such case — the reference ESPHome component decrypts with the EK only and skips authentication. This change lets such meters be read on ESP8266 the same way they already can be on ESP32 (by leaving the auth key blank). Note the ~580 B GAMA 350 telegram still realistically needs an ESP32 for buffer reasons.

## Testing

- Native decoder suite: 16/16 pass, including a new `test_encrypted_decode_without_authkey` that decodes an authenticated fixture (issued with an AK) using the EK only / AK omitted, locking the cross-platform "blank AK skips auth" contract.
- esp8266 builds clean.

The native test exercises the mbedTLS path; the ESP8266 `br_gcm` line is platform-gated and can't be unit-tested on host, but it now mirrors the covered ESP32/native logic.

Refs #1198.
