### PR TITLE
Guard realtime accounting against corrupt NaN/Inf values (#1216)

### DIFF
--- a/src/EnergyAccounting.cpp
+++ b/src/EnergyAccounting.cpp
@@ -8,6 +8,15 @@
 #include "LittleFS.h"
 #include "AmsStorage.h"
 #include "FirmwareVersion.h"
+#include "crc.h"
+#include <cmath>
+#include <cstddef>
+
+// Clamp NaN/Inf to 0 so corrupt floats never leak into JSON/MQTT output
+static float sanitize(float v) {
+    if(std::isnan(v) || std::isinf(v)) return 0.0;
+    return v;
+}
 
 #if defined(AMS_REMOTE_DEBUG)
 EnergyAccounting::EnergyAccounting(RemoteDebug* debugger, EnergyAccountingRealtimeData* rtd) {
@@ -16,7 +25,13 @@ EnergyAccounting::EnergyAccounting(Stream* Stream, EnergyAccountingRealtimeData*
 #endif
     data.version = 1;
     this->debugger = debugger;
-    if(rtd->magic != 0x6A) {
+    realtimeData = rtd;
+    // The realtime struct lives in non-initialized RAM on ESP32 so it survives a
+    // reboot. A single magic byte is not enough to tell valid data from garbage left
+    // by a previous firmware (a layout change can shift fields while the byte still
+    // matches), which produced NaN/Inf values in the API. Validate with a CRC too.
+    uint16_t crc = crc16((uint8_t*) rtd, offsetof(EnergyAccountingRealtimeData, crc));
+    if(rtd->magic != 0x6A || rtd->crc != crc) {
         rtd->magic = 0x6A;
         rtd->currentHour = 0;
         rtd->currentDay = 0;
@@ -29,8 +44,12 @@ EnergyAccounting::EnergyAccounting(Stream* Stream, EnergyAccountingRealtimeData*
         rtd->incomeDay = 0;
         rtd->lastImportUpdateMillis = 0;
         rtd->lastExportUpdateMillis = 0;
+        updateRealtimeCrc();
     }
-    realtimeData = rtd;
+}
+
+void EnergyAccounting::updateRealtimeCrc() {
+    realtimeData->crc = crc16((uint8_t*) realtimeData, offsetof(EnergyAccountingRealtimeData, crc));
 }
 
 void EnergyAccounting::setup(AmsDataStorage *ds, EnergyAccountingConfig *config) {
@@ -189,6 +208,7 @@ bool EnergyAccounting::update(time_t now, uint64_t lastUpdatedMillis, uint8_t li
         while(getMonthMax() > config->thresholds[realtimeData->currentThresholdIdx] && realtimeData->currentThresholdIdx < 10) realtimeData->currentThresholdIdx++;
     }
 
+    updateRealtimeCrc();
     return ret;
 }
 
@@ -231,7 +251,7 @@ void EnergyAccounting::calcDayCost() {
 }
 
 float EnergyAccounting::getUseThisHour() {
-    return realtimeData->use;
+    return sanitize(realtimeData->use);
 }
 
 float EnergyAccounting::getUseToday() {
@@ -265,7 +285,7 @@ float EnergyAccounting::getUseLastMonth() {
 }
 
 float EnergyAccounting::getProducedThisHour() {
-    return realtimeData->produce;
+    return sanitize(realtimeData->produce);
 }
 
 float EnergyAccounting::getProducedToday() {
@@ -299,11 +319,11 @@ float EnergyAccounting::getProducedLastMonth() {
 }
 
 float EnergyAccounting::getCostThisHour() {
-    return realtimeData->costHour;
+    return sanitize(realtimeData->costHour);
 }
 
 float EnergyAccounting::getCostToday() {
-    return realtimeData->costDay;
+    return sanitize(realtimeData->costDay);
 }
 
 float EnergyAccounting::getCostYesterday() {
@@ -319,11 +339,11 @@ float EnergyAccounting::getCostLastMonth() {
 }
 
 float EnergyAccounting::getIncomeThisHour() {
-    return realtimeData->incomeHour;
+    return sanitize(realtimeData->incomeHour);
 }
 
 float EnergyAccounting::getIncomeToday() {
-    return realtimeData->incomeDay;
+    return sanitize(realtimeData->incomeDay);
 }
 
 float EnergyAccounting::getIncomeYesterday() {

--- a/src/EnergyAccounting.h
+++ b/src/EnergyAccounting.h
@@ -67,6 +67,7 @@ struct EnergyAccountingRealtimeData {
     float incomeDay;
     unsigned long lastImportUpdateMillis;
     unsigned long lastExportUpdateMillis;
+    uint16_t crc;
 };
 
 
@@ -134,6 +135,7 @@ private:
 
     void calcDayCost();
     bool updateMax(uint16_t val, uint8_t day, uint8_t hour);
+    void updateRealtimeCrc();
 };
 
 #endif


### PR DESCRIPTION
## Problem

Issue #1216: after a firmware upgrade, `data.json` returned invalid JSON like `"i": -nan` and absurd cost values (e.g. `9.5e25`) under `ea.h`, breaking the dashboard.

## Root cause

`EnergyAccountingRealtimeData` lives in non-initialized RAM on ESP32 (`__NOINIT_ATTR` in `AmsToMqttBridge.cpp`) so realtime accounting survives a reboot. It was validated only by a single magic byte (`0x6A`). That is not enough to distinguish valid data from garbage left by a *previous* firmware: a struct-layout change across an upgrade can shift fields while byte 0 still happens to equal `0x6A`, so stale bytes get reinterpreted as floats (yielding NaN / huge values). Those floats were then served verbatim via `%.2f`, and the toolchain prints NaN as `-nan` — invalid JSON.

This matches the report: a C3 board reflashed across versions during development, while another device upgraded cleanly.

## Fix

Two complementary layers:

1. **CRC guard** — add a `crc16` over the struct contents (reusing `src/decoder/.../crc.h`). The struct is reinitialized when either the magic byte *or* the CRC mismatches, so stale RAM from an incompatible build is discarded. The CRC is refreshed at the end of every `update()`.
2. **Sanitize** — the realtime getters now clamp NaN/Inf to `0`, so corrupt floats can never leak into JSON/MQTT output. Mirrors the existing `std::isnan` guard in `getUseLastMonth()`.

## Verification

- `pio run -e esp32c3dev` — SUCCESS (reported device)
- `pio run -e esp8266dev` — SUCCESS (non-NOINIT path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)