### PR TITLE
Track last SNTP sync time to flag a stale clock on the Services tile

### DIFF
--- a/src/AmsToMqttBridge.cpp
+++ b/src/AmsToMqttBridge.cpp
@@ -101,6 +101,7 @@ ADC_MODE(ADC_VCC);
 #include "PulseMeterCommunicator.h"
 
 #include "Uptime.h"
+#include "NtpStatus.h"
 
 #if defined(AMS_REMOTE_DEBUG)
 #include "RemoteDebug.h"
@@ -698,6 +699,8 @@ void setup() {
 	ea.load();
 	ea.setPriceService(ps);
 	ws.setup(&config, &gpioConfig, &meterState, &ds, &ea, &rtp, &updater);
+
+	ntpRegisterSyncCallback();
 
 	UiConfig ui;
 	if(config.getUiConfig(ui)) {

--- a/src/AmsWebServer.cpp
+++ b/src/AmsWebServer.cpp
@@ -8,6 +8,7 @@
 #include "CustomDefaults.h"
 #include "AmsWebHeaders.h"
 #include "FirmwareVersion.h"
+#include "NtpStatus.h"
 #include "base64.h"
 #include "hexutils.h"
 #include "AmsJsonGenerator.h"
@@ -312,6 +313,10 @@ uint8_t AmsWebServer::mqttHandlerState(AmsMqttHandler* h) {
 	return h->lastError() == 0 ? 2 : 3;
 }
 
+// SNTP resyncs roughly hourly; flag the NTP service as degraded if no sync has
+// landed in this long, allowing a couple of missed cycles before warning.
+#define NTP_STALE_AFTER_SECONDS 10800
+
 String AmsWebServer::buildServicesJson() {
 	String out = "";
 	char entry[320];
@@ -387,7 +392,17 @@ String AmsWebServer::buildServicesJson() {
 		NtpConfig ntp;
 		if(config->getNtpConfig(ntp) && ntp.enable) {
 			const char* server = strlen(ntp.server) > 0 ? ntp.server : "pool.ntp.org";
-			uint8_t s = time(nullptr) > FirmwareVersion::BuildEpoch ? 1 : 2;
+			// A set-but-stale clock (NTP stopped resyncing) silently corrupts
+			// day-boundary accounting, so flag staleness rather than only
+			// reporting whether the clock was ever set.
+			uint64_t lastSync = ntpLastSyncMillis();
+			uint8_t s;
+			if(lastSync == 0) {
+				s = 2; // No SNTP sync since boot yet
+			} else {
+				uint32_t ageSec = (uint32_t) ((millis64() - lastSync) / 1000);
+				s = ageSec > NTP_STALE_AFTER_SECONDS ? 2 : 1;
+			}
 			snprintf_P(entry, sizeof(entry), PSTR("{\"k\":\"ntp\",\"s\":%d,\"e\":0,\"d\":\"%s\"}"),
 				s, server);
 			if(!out.isEmpty()) out += ",";

--- a/src/NtpStatus.cpp
+++ b/src/NtpStatus.cpp
@@ -1,0 +1,40 @@
+/**
+ * @copyright Utilitech AS 2023-2026
+ * License: Fair Source
+ *
+ */
+
+#include "NtpStatus.h"
+#include "Uptime.h"
+
+#if defined(ESP8266)
+#include <coredecls.h>
+#elif defined(ESP32)
+#include <esp_sntp.h>
+#endif
+
+static uint64_t lastSyncMillis = 0;
+
+uint64_t ntpLastSyncMillis() {
+	return lastSyncMillis;
+}
+
+#if defined(ESP8266)
+// from_sntp is false when the clock is set manually (e.g. from the meter
+// timestamp), so we only record actual SNTP syncs here.
+static void onTimeSync(bool from_sntp) {
+	if(from_sntp) lastSyncMillis = millis64();
+}
+#elif defined(ESP32)
+static void onTimeSync(struct timeval* tv) {
+	lastSyncMillis = millis64();
+}
+#endif
+
+void ntpRegisterSyncCallback() {
+#if defined(ESP8266)
+	settimeofday_cb(onTimeSync);
+#elif defined(ESP32)
+	sntp_set_time_sync_notification_cb(onTimeSync);
+#endif
+}

--- a/src/NtpStatus.h
+++ b/src/NtpStatus.h
@@ -1,0 +1,20 @@
+/**
+ * @copyright Utilitech AS 2023-2026
+ * License: Fair Source
+ *
+ */
+
+#ifndef _NTPSTATUS_H
+#define _NTPSTATUS_H
+
+#include <stdint.h>
+
+// Registers the platform SNTP sync-notification callback. Call once during setup.
+void ntpRegisterSyncCallback();
+
+// millis64() value captured at the last successful SNTP sync, or 0 if no SNTP
+// sync has happened since boot. Used to detect a clock that is set but stale
+// (NTP stopped resyncing), which silently corrupts day-boundary accounting.
+uint64_t ntpLastSyncMillis();
+
+#endif


### PR DESCRIPTION
## Summary

The NTP entry on the new Services status tile only checks whether the system clock has *ever* been set (`time() > BuildEpoch` in `AmsWebServer.cpp`). That misses the failure mode behind #1191: a clock that synced once and then silently stopped resyncing keeps ticking from `millis()`, so the tile stays **green** even while the clock drifts and day-boundary energy accounting gets corrupted (and the GUI shows the wrong time).

This adds a real *freshness* signal.

## Changes

- New `src/NtpStatus.{h,cpp}` — registers a platform SNTP sync-notification callback that records `millis64()` at each successful sync, exposed via `ntpLastSyncMillis()`:
  - **ESP8266**: `settimeofday_cb(void(*)(bool from_sntp))` — the `from_sntp` flag lets us ignore the meter-timestamp `settimeofday()` at `AmsToMqttBridge.cpp:1734`, so only real SNTP syncs count.
  - **ESP32**: `sntp_set_time_sync_notification_cb(void(*)(struct timeval*))`.
- `AmsToMqttBridge.cpp` — register the callback once in `setup()`.
- `AmsWebServer.cpp` — the Services tile NTP status is now **yellow** when there has been no SNTP sync since boot or the last sync is older than 3h (`NTP_STALE_AFTER_SECONDS`), and **green** only on a recent sync. Maps onto the existing `bcol()` colors; no UI changes needed.

Diagnostic only — **no change to the accounting logic.**

## Why draft

Investigating #1191. The reporter notes the GUI is **exactly 1 hour off**, which looks more like a DST/meter-timestamp-deviation issue than NTP drift. This PR is the diagnostic that will tell us whether NTP is actually still syncing on affected devices; root cause may turn out to be elsewhere (the meter-timestamp decode / `tz` DST handling). Waiting on a data dump from the reporter before deciding whether more is needed here.

## Testing

- `pio run -e esp8266dev` → SUCCESS (confirms `settimeofday_cb(bool)` overload)
- `pio run -e esp32dev` → SUCCESS (confirms `esp_sntp.h` / `sntp_set_time_sync_notification_cb`)

Related: #1191

🤖 Generated with [Claude Code](https://claude.com/claude-code)