### PR TITLE
Pad HA price arrays with null to clear stale future-price sensors (#1188)

### DIFF
--- a/src/mqtt/HomeAssistantMqttHandler.cpp
+++ b/src/mqtt/HomeAssistantMqttHandler.cpp
@@ -420,6 +420,7 @@ bool HomeAssistantMqttHandler::publishPrices(PriceService* ps) {
 
     uint8_t currentPricePointIndex = ps->getCurrentPricePointIndex();
 	uint8_t numberOfPoints = ps->getNumberOfPointsAvailable();
+	uint8_t emitted = 0;
 	for(int i = currentPricePointIndex; i < numberOfPoints; i++) {
 		float val = ps->getPricePoint(PRICE_DIRECTION_IMPORT, i);
         if(val == PRICE_NO_VALUE) {
@@ -427,10 +428,18 @@ bool HomeAssistantMqttHandler::publishPrices(PriceService* ps) {
         } else {
             pos += snprintf_P(json+pos, BufferSize-pos, PSTR("%.4f,"), val);
         }
+        emitted++;
 	}
+    // Pad with null up to the number of discovery sensors created (high-water mark),
+    // so HA sensors past the end of the current data render as unknown instead of
+    // freezing on their last value (IndexError keeps the previous state otherwise).
+    for(; emitted <= priceImportInit; emitted++) {
+        pos += snprintf_P(json+pos, BufferSize-pos, PSTR("null,"));
+    }
     if(rteInit && ps->isExportPricesDifferentFromImport()) {
         pos--;
         pos += snprintf_P(json+pos, BufferSize-pos, PSTR("],\"export\":["));
+        emitted = 0;
         for(int i = currentPricePointIndex; i < numberOfPoints; i++) {
             float val = ps->getPricePoint(PRICE_DIRECTION_EXPORT, i);
             if(val == PRICE_NO_VALUE) {
@@ -438,6 +447,10 @@ bool HomeAssistantMqttHandler::publishPrices(PriceService* ps) {
             } else {
                 pos += snprintf_P(json+pos, BufferSize-pos, PSTR("%.4f,"), val);
             }
+            emitted++;
+        }
+        for(; emitted <= priceExportInit; emitted++) {
+            pos += snprintf_P(json+pos, BufferSize-pos, PSTR("null,"));
         }
     }
 


### PR DESCRIPTION
Fixes #1188

## Problem

Home Assistant payload type reports wrong future prices: after midnight, the per-hour price sensors freeze on the last known value and repeat it for the rest of the (now expired) window — what the reporter saw as "the last point before midnight reused" for ~22 hours.

## Root cause

The `/prices` JSON itself is correct — it only carries the real future points. The issue is the HA discovery sensors:

- `publishPriceSensors()` creates one sensor per future hour (`prices.import[N]`), and the count only ever grows (`priceImportInit` / `priceExportInit` are high-water marks). Once tomorrow's prices are published around 13:00, ~34 sensors exist permanently.
- After midnight the array shrinks back to the points remaining until next midnight. Sensors for the now-missing tail index **past the end** of the array.
- Jinja raises `IndexError` on out-of-range list access, so the value template fails to render and **HA keeps the sensor's previous state** — the stale repeated price.

## Fix

Pad the `import`/`export` arrays in `publishPrices()` with `null` up to the discovery high-water mark, so every existing sensor's index resolves. Out-of-data hours render `null | is_defined` → `None`, showing as **unknown** in HA instead of a stale value. The raw JSON is also more honest for non-HA consumers (trailing `null`s rather than a silently shrinking array).

Pure HomeAssistant-handler change; no decoder impact.

## Verification

- `pio run -e esp32dev` builds clean.
- Buffer is safe: ≤38 entries × ~8 chars per array, well under the 2048 `BufferSize`.
- Existing trailing-comma trims (`pos--`) still hold since padding always leaves a trailing `,`.
- Device-level confirmation: after tomorrow's prices expire at midnight, the "Import price in N hours" sensors beyond the available window should report **unknown** rather than the last known price.

🤖 Generated with [Claude Code](https://claude.com/claude-code)