### PR TITLE
Fix mDNS network change detection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,10 +66,9 @@ jobs:
     - name: PlatformIO lib install
       run: pio pkg install
     - name: PlatformIO run
-      # Device firmware envs only. The 'native' unit-test env is built via
-      # `pio test -e native`, not `pio run`.
+      # Device firmware envs only. Native unit-test envs are run separately.
       run: pio run -e esp8266 -e esp32 -e esp32s2 -e esp32solo -e esp32c3 -e esp32s3
-    - name: Decoder unit tests (native)
+    - name: Native unit tests
       # Encrypted-fixture decode tests read keys from these secrets; without
       # them those tests self-skip (unencrypted + golden tests still run).
       env:
@@ -79,4 +78,6 @@ jobs:
         AMS_TEST_KEY_GH905_EK: ${{ secrets.AMS_TEST_KEY_GH905_EK }}
         AMS_TEST_KEY_EM20200710_EK: ${{ secrets.AMS_TEST_KEY_EM20200710_EK }}
         AMS_TEST_KEY_EM20200710_AK: ${{ secrets.AMS_TEST_KEY_EM20200710_AK }}
-      run: pio test -e native
+      run: |
+        pio test -e native
+        pio test -e native_config

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -48,7 +48,7 @@ jobs:
       is_esp32: false
 
   test:
-    name: Decoder unit tests (native)
+    name: Native unit tests
     runs-on: ubuntu-latest
     steps:
       - name: Check out code from repo
@@ -63,7 +63,7 @@ jobs:
           pip install -U platformio
       - name: Install mbedTLS (native decrypt tests)
         run: sudo apt-get update && sudo apt-get install -y libmbedtls-dev
-      - name: Run decoder tests
+      - name: Run native tests
         # Encrypted-fixture tests read keys from these secrets; absent (e.g. on
         # fork PRs) they self-skip, while unencrypted + golden tests still run.
         env:
@@ -73,7 +73,9 @@ jobs:
           AMS_TEST_KEY_GH905_EK: ${{ secrets.AMS_TEST_KEY_GH905_EK }}
           AMS_TEST_KEY_EM20200710_EK: ${{ secrets.AMS_TEST_KEY_EM20200710_EK }}
           AMS_TEST_KEY_EM20200710_AK: ${{ secrets.AMS_TEST_KEY_EM20200710_AK }}
-        run: pio test -e native
+        run: |
+          pio test -e native
+          pio test -e native_config
 
   comment:
     needs:

--- a/platformio.ini
+++ b/platformio.ini
@@ -186,3 +186,22 @@ build_src_filter =
     +<AmsData.cpp>
     +<LNG.cpp>
     +<LNG2.cpp>
+
+[env:native_config]
+platform = native
+build_flags =
+    -D NATIVE_TEST
+    -I src/decoder/include
+    -I src
+    -I test/stubs
+    -std=c++17
+    -fsanitize=address
+    -fno-omit-frame-pointer
+build_type = debug
+test_framework = unity
+test_filter = test_configuration
+test_build_src = yes
+build_src_filter =
+    -<*>
+    +<AmsConfiguration.cpp>
+    +<hexutils.cpp>

--- a/src/AmsConfiguration.cpp
+++ b/src/AmsConfiguration.cpp
@@ -89,6 +89,7 @@ bool AmsConfiguration::setNetworkConfig(NetworkConfig& config) {
 			networkChanged |= strcmp(config.dns2, existing.dns2) != 0;
 		}
 		networkChanged |= strcmp(config.hostname, existing.hostname) != 0;
+		networkChanged |= config.mdns != existing.mdns;
 		networkChanged |= config.power != existing.power;
 		networkChanged |= config.sleep != existing.sleep;
 		networkChanged |= config.use11b != existing.use11b;

--- a/src/decoder/include/DebugPrint.h
+++ b/src/decoder/include/DebugPrint.h
@@ -33,6 +33,7 @@
     size_t println(const char* s = "") {
       return print(s) + print("\n");
     }
+    virtual void flush() {}
     size_t printf(const char* fmt, ...) {
       va_list args;
       va_start(args, fmt);

--- a/test/stubs/Arduino.h
+++ b/test/stubs/Arduino.h
@@ -26,8 +26,30 @@
 #ifndef PSTR
 #define PSTR(x) (x)
 #endif
+#ifndef strcpy_P
+#define strcpy_P strcpy
+#endif
+#ifndef strncmp_P
+#define strncmp_P strncmp
+#endif
+#ifndef snprintf_P
+#define snprintf_P snprintf
+#endif
+#ifndef INPUT_PULLUP
+#define INPUT_PULLUP 0x2
+#endif
 
 typedef uint8_t byte;
 typedef bool boolean;
+
+inline void delay(unsigned long) {}
+inline void pinMode(uint8_t, uint8_t) {}
+
+class NativeESPClass {
+public:
+    uint32_t getChipId() const { return 0x123456; }
+};
+
+inline NativeESPClass ESP;
 
 #endif

--- a/test/stubs/EEPROM.h
+++ b/test/stubs/EEPROM.h
@@ -2,10 +2,43 @@
  * @copyright Utilitech AS 2023-2026
  * License: Fair Source
  *
- * Native shim for <EEPROM.h>. AmsConfiguration.h includes it, but the native
- * decode path never touches persistent storage (AmsConfiguration.cpp is not
- * compiled for the native env), so this only needs to exist.
+ * Native in-memory shim for <EEPROM.h>.
  */
 #ifndef _NATIVE_EEPROM_H
 #define _NATIVE_EEPROM_H
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+class EEPROMClass {
+public:
+    bool begin(size_t size) { return size <= data.size(); }
+    bool commit() { return true; }
+
+    uint8_t read(int address) const {
+        return data.at(static_cast<size_t>(address));
+    }
+
+    template<typename T>
+    T& get(int address, T& value) const {
+        std::memcpy(&value, data.data() + address, sizeof(T));
+        return value;
+    }
+
+    template<typename T>
+    const T& put(int address, const T& value) {
+        std::memcpy(data.data() + address, &value, sizeof(T));
+        return value;
+    }
+
+    void reset() { data.fill(0); }
+
+private:
+    std::array<uint8_t, 4096> data = {};
+};
+
+inline EEPROMClass EEPROM;
+
 #endif

--- a/test/test_configuration/test_main.cpp
+++ b/test/test_configuration/test_main.cpp
@@ -1,0 +1,59 @@
+/**
+ * @copyright Utilitech AS 2023-2026
+ * License: Fair Source
+ */
+
+#include <unity.h>
+
+#include "AmsConfiguration.h"
+
+void setUp(void) {
+    EEPROM.reset();
+}
+
+void tearDown(void) {}
+
+static AmsConfiguration loadConfigurationWith(NetworkConfig& network) {
+    uint8_t version = EEPROM_EXPECTED_VERSION;
+    EEPROM.put(EEPROM_CONFIG_ADDRESS, version);
+    EEPROM.put(CONFIG_NETWORK_START, network);
+
+    AmsConfiguration configuration;
+    configuration.load();
+    configuration.ackNetworkConfigChange();
+    return configuration;
+}
+
+static NetworkConfig makeNetworkConfig(bool mdns) {
+    NetworkConfig network = {};
+    network.mdns = mdns;
+    network.mode = 1;
+    network.sleep = 1;
+    return network;
+}
+
+void test_unchanged_network_config_does_not_mark_network_changed(void) {
+    NetworkConfig network = makeNetworkConfig(false);
+    AmsConfiguration configuration = loadConfigurationWith(network);
+
+    TEST_ASSERT_TRUE(configuration.hasConfig());
+    TEST_ASSERT_FALSE(configuration.setNetworkConfig(network));
+    TEST_ASSERT_FALSE(configuration.isNetworkConfigChanged());
+}
+
+void test_mdns_change_marks_network_changed(void) {
+    NetworkConfig network = makeNetworkConfig(false);
+    AmsConfiguration configuration = loadConfigurationWith(network);
+    network.mdns = true;
+
+    TEST_ASSERT_TRUE(configuration.hasConfig());
+    TEST_ASSERT_TRUE(configuration.setNetworkConfig(network));
+    TEST_ASSERT_TRUE(configuration.isNetworkConfigChanged());
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_unchanged_network_config_does_not_mark_network_changed);
+    RUN_TEST(test_mdns_change_marks_network_changed);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary
- treat mDNS enablement changes as network changes so saving the setting triggers the required reboot
- add a native AmsConfiguration regression suite backed by an in-memory EEPROM stub
- run the new configuration suite in pull-request and main-branch CI

## Testing
- pio test -e native_config
- verified red/green: the mDNS assertion fails without the production fix and passes with it
- pio run -e esp8266
- pio run -e esp32s2