### PR TITLE
Fail the build when ui/dist is missing instead of warning

### DIFF
--- a/scripts/generate_includes.py
+++ b/scripts/generate_includes.py
@@ -18,6 +18,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 import gzip
 
 try:
@@ -138,7 +139,15 @@ if os.path.exists(ui_dist):
             else:
                 write_progmem_raw(dstfile, vname, content_bytes)
 else:
-    print(f"WARN: UI dist not found at '{ui_dist}' — skipping UI header generation. Run 'npm run build' in ui/")
+    # Skipping would leave the previously generated headers in place. They are
+    # gitignored, so they survive branch switches and cleans, and the asset URLs
+    # baked into index.html keep pointing at whatever version generated them
+    # while addversion.py stamps the current one into the route. The build then
+    # succeeds and the UI 404s.
+    sys.exit(
+        f"ERROR: UI dist not found at '{ui_dist}'. Run 'npm run build' in ui/ "
+        "before building the firmware."
+    )
 
 # ---------------------------------------------------------------------------
 # 2. CustomDefaults.h — bridge for the custom/ overlay's config.h


### PR DESCRIPTION
## Change

`scripts/generate_includes.py` printed a warning and carried on when the UI dist was absent:

```python
else:
    print(f"WARN: UI dist not found at '{ui_dist}' — skipping UI header generation. …")
```

It now exits non-zero instead. A missing UI build cannot produce working firmware, so the build should stop rather than emit a binary that looks fine.

## Why the silent skip is dangerous

The generated headers in `src/webserver/html/` are gitignored, so they are local artifacts that survive branch switches and PlatformIO cleans. Skipping regeneration leaves them in place, which splits the UI cache-busting scheme in half:

| | source | value after a skipped regeneration |
|---|---|---|
| asset URL in `index.html` | `src/webserver/html/index_html.h` (this script) | whichever version last generated it |
| route in `AmsWebServer` | `src/generated_version.h` (`addversion.py`, rewritten every build) | current |

The route answers `/index-<current>.js` while the HTML asks for `/index-<old>.js`, so the UI 404s on both `.js` and `.css` while the build reports success.

## Scope

This is defensive hardening, not a fix for a live bug. In a normal clone `ui/dist` is tracked, so the branch is effectively unreachable — it only triggers if someone deletes the directory. It costs one line and turns a silently broken binary into a build error, but close this if you would rather not have the extra failure mode.

## Verification

- With `ui/dist` moved aside: exits 1 with `ERROR: UI dist not found at 'ui/dist'. Run 'npm run build' in ui/ before building the firmware.`
- With `ui/dist` present: exits 0, generated headers unchanged, no stray files.
- `pio test` unaffected: `[env:native]` overrides `extra_scripts` to `pre:scripts/native_crypto.py` and `[env:native_config]` sets none, so neither runs this script. `pull-request.yml` only runs the native tests.
- Firmware workflows unaffected: `build.yml` and `pr-build-env.yml` both run `npm ci && npm run build` before `pio run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
