### PR TITLE
Stop IPv6 DNS servers from evicting the IPv4 ones

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -21,6 +21,10 @@ build_flags =
     -I src/cloud
 
 [esp32]
+# Lets DnsGuard intercept lwIP writes to the DNS server table
+build_flags =
+    -D AMS_WRAP_DNS_SETSERVER
+    -Wl,--wrap=dns_setserver
 lib_deps = WiFi, Ethernet, ESPmDNS, WiFiClientSecure, HTTPClient, FS, WebServer, ESP32 Async UDP, ESP32SSDP, mulmer89/ESPRandom@1.5.0, ${common.lib_deps}
 
 [env:esp8266]
@@ -42,6 +46,7 @@ board_build.f_cpu = 160000000L
 board_build.partitions = custom_partition.csv
 build_flags =
     ${common.build_flags}
+    ${esp32.build_flags}
     -D AMS_REMOTE_DEBUG=1
     -D AMS_CLOUD=1
     -D AMS_KMP=1
@@ -67,6 +72,7 @@ board_build.f_flash = 40000000L
 board_build.partitions = custom_partition.csv
 build_flags =
     ${common.build_flags}
+    ${esp32.build_flags}
     -D AMS_REMOTE_DEBUG=1
     -D AMS_CLOUD=1
     -D AMS_KMP=1
@@ -89,6 +95,7 @@ board = lolin_s2_mini
 board_build.partitions = custom_partition.csv
 build_flags =
     ${common.build_flags}
+    ${esp32.build_flags}
     -D AMS_REMOTE_DEBUG=1
     -D AMS_CLOUD=1
     -D AMS_KMP=1
@@ -107,6 +114,7 @@ board_build.f_cpu = 160000000L
 board_build.partitions = custom_partition.csv
 build_flags =
     ${common.build_flags}
+    ${esp32.build_flags}
     -DFRAMEWORK_ARDUINO_SOLO1
     -D AMS_REMOTE_DEBUG=1
     -D AMS_CLOUD=1
@@ -126,6 +134,7 @@ board_build.mcu = esp32c3
 board_build.partitions = custom_partition.csv
 build_flags =
     ${common.build_flags}
+    ${esp32.build_flags}
     -D AMS_REMOTE_DEBUG=1
     -D AMS_CLOUD=1
     -D AMS_KMP=1
@@ -143,6 +152,7 @@ board = esp32-s3-devkitc-1
 board_build.mcu = esp32s3
 build_flags =
     ${common.build_flags}
+    ${esp32.build_flags}
     -D AMS_REMOTE_DEBUG=1
     -D AMS_CLOUD=1
     -D AMS_KMP=1

--- a/src/AmsToMqttBridge.cpp
+++ b/src/AmsToMqttBridge.cpp
@@ -21,7 +21,7 @@ ADC_MODE(ADC_VCC);
 #include <ESPmDNS.h>
 #include <ESP32SSDP.h>
 #include <esp_task_wdt.h>
-#include <lwip/dns.h>
+#include "DnsGuard.h"
 #if defined(BOARD_HAS_PSRAM)
 #include <esp_heap_caps.h>
 #include <mbedtls/platform.h>
@@ -332,41 +332,15 @@ bool checkVoltageIfNeeded(float range) {
 }
 
 #if defined(ESP32)
-uint8_t dnsState = 0;
-ip_addr_t dns0;
 void WiFiEvent(WiFiEvent_t event, WiFiEventInfo_t info) {
 	if(setupMode) return; // None of this necessary in setup mode
 	if(ch != NULL) ch->eventHandler(event, info);
 	switch(event) {
-		case ARDUINO_EVENT_ETH_CONNECTED:
-		case ARDUINO_EVENT_WIFI_STA_CONNECTED: {
-			dnsState = 0;
-			if(ch != NULL) {
-				NetworkConfig conf;
-				ch->getCurrentConfig(conf);
-				if(conf.ipv6) {
-					dnsState = 2; // Never reset if IPv6 is enabled
-					debugI_P(PSTR("IPv6 enabled, not monitoring DNS poisoning"));
-				}
-			}
-			break;
-		}
 		case ARDUINO_EVENT_ETH_GOT_IP:
-		case ARDUINO_EVENT_WIFI_STA_GOT_IP: {
-			if(dnsState == 0) {
-				const ip_addr_t* dns = dns_getserver(0);
-				memcpy(&dns0, dns, sizeof(dns0));
-
-				IPAddress res;
-				int ret = WiFi.hostByName("hub.amsleser.no", res);
-				if(ret == 0) {
-					dnsState = 2;
-					debugI_P(PSTR("No DNS, probably a closed network"));
-				} else if(dnsState == 0) {
-					debugI_P(PSTR("DNS is present and working, monitoring DNS poisoning"));
-					dnsState = 1;
-				}
-			}
+		case ARDUINO_EVENT_WIFI_STA_GOT_IP:
+		case ARDUINO_EVENT_ETH_GOT_IP6:
+		case ARDUINO_EVENT_WIFI_STA_GOT_IP6: {
+			dnsGuardEnforce(); // This is when the DNS table is written
 			break;
 		}
 		case ARDUINO_EVENT_ETH_DISCONNECTED:
@@ -736,6 +710,9 @@ bool longPressActive = false;
 
 unsigned long lastTemperatureRead = 0;
 unsigned long lastSysupdate = 0;
+#if defined(ESP32)
+uint32_t lastDnsRepairs = 0;
+#endif
 uint64_t lastErrorBlink = 0; 
 unsigned long lastVoltageCheck = 0;
 int lastError = 0;
@@ -785,6 +762,14 @@ void loop() {
 			if(!networkConnected) {
 				postConnect();
 			}
+
+			#if defined(ESP32)
+			dnsGuardEnforce();
+			if(dnsGuardRepairs() != lastDnsRepairs) {
+				lastDnsRepairs = dnsGuardRepairs();
+				debugI_P(PSTR("Had to restore the IPv4 DNS servers (%d)"), lastDnsRepairs);
+			}
+			#endif
 
 			// Only do these tasks if we have super-smooth voltage
 			if(checkVoltageIfNeeded(0.1)) {
@@ -1381,16 +1366,6 @@ void handleSystem(unsigned long now) {
 		if(end - start > SLOW_PROC_TRIGGER_MS) {
 			debugW_P(PSTR("Used %dms to send system update to MQTT"), end-start);
 		}
-
-		#if defined(ESP32)
-		if(dnsState == 1) {
-			const ip_addr_t* dns = dns_getserver(0);
-			if(memcmp(&dns0, dns, sizeof(dns0)) != 0) {
-					dns_setserver(0, &dns0);
-					debugI_P(PSTR("Had to reset DNS server"));
-			}
-		}
-		#endif
 	}
 }
 
@@ -1584,6 +1559,9 @@ void connectToNetwork() {
 				setupMode = false;
 				toggleSetupMode();
 		}
+		#if defined(ESP32)
+		dnsGuardSetIpv6Allowed(network.ipv6);
+		#endif
 		ch->connect(network, sysConfig);
 		ws.setConnectionHandler(ch);
 		#if defined(_CLOUDCONNECTOR_H)

--- a/src/DnsGuard.cpp
+++ b/src/DnsGuard.cpp
@@ -1,0 +1,144 @@
+/**
+ * @copyright Utilitech AS 2023-2026
+ * License: Fair Source
+ * 
+ * @brief Keeps the IPv4 DNS servers from being evicted by IPv6 ones
+ * 
+ * @details lwIP keeps a single global DNS server table, and both nd6 RDNSS and
+ * stateless DHCPv6 start writing IPv6 servers at index 0, evicting the IPv4
+ * servers handed out by DHCP. RDNSS is re-applied on every router
+ * advertisement, and those are processed even when IPv6 is disabled in our
+ * configuration, since lwIP is always joined to the link-local all-nodes group.
+ * 
+ * We therefore reserve the first slots of the table for IPv4 and the last one
+ * for IPv6, which lets both stacks resolve names on a dual stack network.
+ * 
+ * The table is touched from the lwIP thread, the network event handler and the
+ * main loop. All the state here is word sized and every disagreement is fixed
+ * by the next reconcile, so no locking is needed. Taking one on the lwIP thread
+ * would not be safe anyway.
+ */
+
+#include "DnsGuard.h"
+
+#if defined(ESP32)
+
+#include <lwip/dns.h>
+
+#if DNS_MAX_SERVERS < 3
+#error "DnsGuard needs room for both an IPv4 and an IPv6 DNS server"
+#endif
+
+// Slots reserved for IPv4, the remaining one is where IPv6 is parked
+#define DNS_V4_SLOTS (DNS_MAX_SERVERS - 1)
+
+extern "C" void __real_dns_setserver(u8_t numdns, const ip_addr_t *dnsserver);
+
+static ip4_addr_t knownDns[DNS_V4_SLOTS];
+static bool ipv6Allowed = false;
+static uint32_t repairs = 0;
+
+static bool isUsableV4(const ip_addr_t* server) {
+	return server != NULL && IP_IS_V4(server) && !ip_addr_isany(server);
+}
+
+static bool hasV4Server() {
+	for(uint8_t i = 0; i < DNS_MAX_SERVERS; i++) {
+		if(isUsableV4(dns_getserver(i))) return true;
+	}
+	return false;
+}
+
+#if defined(AMS_WRAP_DNS_SETSERVER)
+/**
+ * Intercepts every write to the DNS table. Runs on the lwIP thread, so it must
+ * not block or log.
+ */
+extern "C" void __wrap_dns_setserver(u8_t numdns, const ip_addr_t *dnsserver) {
+	// Only displace an IPv6 server when there is an IPv4 one worth protecting
+	if(dnsserver != NULL && IP_IS_V6(dnsserver) && hasV4Server()) {
+		if(ipv6Allowed) {
+			__real_dns_setserver(DNS_MAX_SERVERS - 1, dnsserver);
+		}
+		return;
+	}
+	__real_dns_setserver(numdns, dnsserver);
+}
+#endif
+
+/**
+ * Remember the IPv4 servers, but only while the IPv4 slots are untainted, so a
+ * table that has already been overwritten can never become the source of truth.
+ * The IPv6 slot is deliberately not read here.
+ */
+static void remember() {
+	for(uint8_t i = 0; i < DNS_V4_SLOTS; i++) {
+		if(IP_IS_V6(dns_getserver(i))) return;
+	}
+
+	ip4_addr_t found[DNS_V4_SLOTS];
+	uint8_t count = 0;
+	for(uint8_t i = 0; i < DNS_V4_SLOTS; i++) {
+		const ip_addr_t* server = dns_getserver(i);
+		if(isUsableV4(server)) {
+			found[count++] = *ip_2_ip4(server);
+		}
+	}
+	if(count == 0) return;
+
+	for(uint8_t i = 0; i < DNS_V4_SLOTS; i++) {
+		if(i < count) {
+			knownDns[i] = found[i];
+		} else {
+			ip4_addr_set_zero(&knownDns[i]);
+		}
+	}
+}
+
+void dnsGuardSetIpv6Allowed(bool allowed) {
+	ipv6Allowed = allowed;
+}
+
+void dnsGuardEnforce() {
+	remember();
+
+	ip_addr_t desired[DNS_MAX_SERVERS];
+	uint8_t count = 0;
+	for(uint8_t i = 0; i < DNS_V4_SLOTS; i++) {
+		if(!ip4_addr_isany_val(knownDns[i])) {
+			ip_addr_copy_from_ip4(desired[count], knownDns[i]);
+			count++;
+		}
+	}
+	if(count == 0) return; // No IPv4 DNS known, leave an IPv6 only or closed network alone
+
+	if(ipv6Allowed) {
+		for(uint8_t i = 0; i < DNS_MAX_SERVERS; i++) {
+			const ip_addr_t* server = dns_getserver(i);
+			if(server != NULL && IP_IS_V6(server) && !ip_addr_isany(server)) {
+				ip_addr_copy(desired[count], *server);
+				count++;
+				break;
+			}
+		}
+	}
+	while(count < DNS_MAX_SERVERS) {
+		ip_addr_set_zero(&desired[count]);
+		count++;
+	}
+
+	bool repaired = false;
+	for(uint8_t i = 0; i < DNS_MAX_SERVERS; i++) {
+		if(!ip_addr_cmp(dns_getserver(i), &desired[i])) {
+			dns_setserver(i, &desired[i]);
+			repaired = true;
+		}
+	}
+	if(repaired) repairs++;
+}
+
+uint32_t dnsGuardRepairs() {
+	return repairs;
+}
+
+#endif

--- a/src/DnsGuard.h
+++ b/src/DnsGuard.h
@@ -1,0 +1,31 @@
+/**
+ * @copyright Utilitech AS 2023-2026
+ * License: Fair Source
+ * 
+ * @brief Keeps the IPv4 DNS servers from being evicted by IPv6 ones
+ */
+
+#ifndef _DNSGUARD_H
+#define _DNSGUARD_H
+
+#if defined(ESP32)
+
+#include <stdint.h>
+
+/**
+ * Whether an IPv6 DNS server is allowed to stay in the table at all. When IPv6
+ * is disabled we have no global IPv6 address, so such a server is unreachable.
+ */
+void dnsGuardSetIpv6Allowed(bool allowed);
+
+/**
+ * Reconcile the lwIP DNS table with the last known good IPv4 servers. Cheap
+ * enough to call from the main loop, safe to call from an event handler.
+ */
+void dnsGuardEnforce();
+
+/** Number of times the table had to be repaired since boot */
+uint32_t dnsGuardRepairs();
+
+#endif
+#endif


### PR DESCRIPTION
Fixes #1141

## Root cause

lwIP keeps a **single global** DNS server table, and IPv6 servers are written starting at index 0, evicting the IPv4 servers DHCP handed out.

`lwip/src/core/ipv6/nd6.c`:

```c
600:  #if LWIP_ND6_RDNSS_MAX_DNS_SERVERS
601:    /* There can be multiple RDNSS options per RA */
602:    u8_t rdnss_server_idx = 0;
...
866:  for (n = 0; (rdnss_server_idx < DNS_MAX_SERVERS) && (n < num); n++, ...) {
879:      dns_setserver(rdnss_server_idx++, &rdnss_address);
```

`rdnss_server_idx` is a **local**, reset on every router advertisement, so this repeats for the lifetime of the connection rather than happening once at boot. The loop bounds on `DNS_MAX_SERVERS` (3 in our builds) rather than `LWIP_ND6_RDNSS_MAX_DNS_SERVERS` (2), so a single advertisement can take out the whole table.

It also happens **whether or not IPv6 is enabled in our configuration**. Advertisements go to `ff02::1`, and `ip6.c:616` accepts that unconditionally:

```c
616:  if (ip6_addr_ismulticast(ip6_current_dest_addr())) {
617:    /* Always joined to multicast if-local and link-local all-nodes group. */
618:    if (ip6_addr_isallnodes_iflocal(...) || ip6_addr_isallnodes_linklocal(...)) {
619:      netif = inp;
```

Our IPv6 setting only controls whether we request a global address, it does not stop nd6 from processing advertisements. The prebuilt libs we link against enable this:

```
CONFIG_LWIP_IPV6_RDNSS_MAX_DNS_SERVERS=2
CONFIG_LWIP_DNS_MAX_SERVERS=3
# CONFIG_LWIP_DNS_SETSERVER_WITH_NETIF is not set   <- no per netif isolation, no hook
```

## Why the old watchdog could not work

* It turned itself off when IPv6 was enabled (`dnsState = 2`), which is exactly the case in #1141.
* It only guarded slot 0, while an advertisement overwrites up to three.
* It took its reference from whatever happened to be in slot 0 at `GOT_IP`. An advertisement arriving before the DHCP ack made the IPv6 address the reference, and it then restored that every 60 seconds for the rest of the connection.
* It probed with a blocking `WiFi.hostByName()` from the network event handler, which stalls the event task, and one transient failure disabled it until the next reconnect.
* 60 second repair latency, and `memcmp` on `ip_addr_t` compares union padding.

## The fix

`src/DnsGuard.{h,cpp}` reserves the first slots of the table for IPv4 and the last one for IPv6, so a dual stack network resolves over both instead of us having to pick one.

**Interception.** `-Wl,--wrap=dns_setserver` catches every write, with no polling latency and no race against the DHCP ack. Verified against the linked image:

```
400c9b24 <ETHClass::config>            -> __wrap_dns_setserver
400e4164 <esp_netif_set_dns_info_api>  -> __wrap_dns_setserver   (WiFi.config, static IP)
400f43f8 <dhcp_handle_ack>             -> __wrap_dns_setserver
400f9400 <nd6_input>                   -> __wrap_dns_setserver   (x2, the RDNSS writes)
```

The only remaining direct calls to the real symbol are `dns_init`'s own intra-TU ones and our wrapper. An IPv6 server is **only** moved or dropped when there is an IPv4 one to protect, so IPv6 only and closed networks are left completely alone. When IPv6 is off in our config the entry is dropped rather than parked, since without a global address it is unreachable anyway.

**Reconciler.** `dnsGuardEnforce()` runs from the main loop and on `GOT_IP`/`GOT_IP6` as a safety net, in case the wrap ever stops matching a future framework. It only ever takes its reference from an IPv4 entry in an untainted slot, so a poisoned table can never become the source of truth. It counts repairs and logs them, so a repair count above zero in the debug log is the signal that the wrap has stopped working.

`-D AMS_WRAP_DNS_SETSERVER` guards the wrapper so an env without the linker flag still builds and gets the reconciler alone.

## Verification

* All 7 targets build: `esp8266`, `esp32`, `esp32s2`, `esp32s2psram`, `esp32solo`, `esp32c3`, `esp32s3`. ESP8266 is untouched, everything is behind `#if defined(ESP32)`.
* `pio test -e native` — 17/17 pass.
* Call site redirection confirmed by disassembling `firmware.elf` as above.

Field verification still wanted: a device on a router that sends RDNSS should now keep its IPv4 DNS on the status page with IPv6 both on and off, and the price service should stay connected.

## Follow ups, not in this PR

* `CONFIG_LWIP_DNS_SETSERVER_WITH_NETIF=y` plus `CONFIG_ESP_NETIF_SET_DNS_PER_DEFAULT_NETIF=y` would fix this at the source if the `custom_sdkconfig` work lands, and the wrap could then go away.
* The `DNS_MAX_SERVERS` vs `LWIP_ND6_RDNSS_MAX_DNS_SERVERS` bound in `nd6.c:866` is worth reporting upstream.
* Worth a look at the price service retry backoff, so a lookup failing during a poisoned window does not keep it down longer than necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)