### PR TITLE
Round scaled config values instead of truncating on cast

### DIFF
--- a/src/AmsToMqttBridge.cpp
+++ b/src/AmsToMqttBridge.cpp
@@ -10,6 +10,7 @@
  */
 
 #include <Arduino.h>
+#include <math.h>
 
 #if defined(ESP8266)
 #include <ESP8266WiFi.h>
@@ -2170,16 +2171,16 @@ void configFileParse() {
 			fromHex(meter.authenticationKey, String(buf+23), 16);
 		} else if(strncmp_P(buf, PSTR("meterWattageMultiplier "), 23) == 0) {
 			if(!lMeter) { config.getMeterConfig(meter); lMeter = true; };
-			meter.wattageMultiplier = String(buf+23).toDouble() * 1000;
+			meter.wattageMultiplier = lround(String(buf+23).toDouble() * 1000.0);
 		} else if(strncmp_P(buf, PSTR("meterVoltageMultiplier "), 23) == 0) {
 			if(!lMeter) { config.getMeterConfig(meter); lMeter = true; };
-			meter.voltageMultiplier = String(buf+23).toDouble() * 1000;
+			meter.voltageMultiplier = lround(String(buf+23).toDouble() * 1000.0);
 		} else if(strncmp_P(buf, PSTR("meterAmperageMultiplier "), 24) == 0) {
 			if(!lMeter) { config.getMeterConfig(meter); lMeter = true; };
-			meter.amperageMultiplier = String(buf+24).toDouble() * 1000;
+			meter.amperageMultiplier = lround(String(buf+24).toDouble() * 1000.0);
 		} else if(strncmp_P(buf, PSTR("meterAccumulatedMultiplier "), 27) == 0) {
 			if(!lMeter) { config.getMeterConfig(meter); lMeter = true; };
-			meter.accumulatedMultiplier = String(buf+27).toDouble() * 1000;
+			meter.accumulatedMultiplier = lround(String(buf+27).toDouble() * 1000.0);
 		} else if(strncmp_P(buf, PSTR("gpioHanPin "), 11) == 0) {
 			if(!lMeter) { config.getMeterConfig(meter); lMeter = true; };
 			meter.rxPin = String(buf+11).toInt();
@@ -2218,13 +2219,13 @@ void configFileParse() {
 			gpio.vccPin = String(buf+11).toInt();
 		} else if(strncmp_P(buf, PSTR("gpioVccOffset "), 14) == 0) {
 			if(!lGpio) { config.getGpioConfig(gpio); lGpio = true; };
-			gpio.vccOffset = String(buf+14).toFloat() * 100;
+			gpio.vccOffset = lround(String(buf+14).toDouble() * 100.0);
 		} else if(strncmp_P(buf, PSTR("gpioVccMultiplier "), 18) == 0) {
 			if(!lGpio) { config.getGpioConfig(gpio); lGpio = true; };
-			gpio.vccMultiplier = String(buf+18).toFloat() * 1000;
+			gpio.vccMultiplier = lround(String(buf+18).toDouble() * 1000.0);
 		} else if(strncmp_P(buf, PSTR("gpioVccBootLimit "), 17) == 0) {
 			if(!lGpio) { config.getGpioConfig(gpio); lGpio = true; };
-			gpio.vccBootLimit = String(buf+17).toFloat() * 10;
+			gpio.vccBootLimit = lround(String(buf+17).toDouble() * 10.0);
 		} else if(strncmp_P(buf, PSTR("gpioVccResistorGnd "), 19) == 0) {
 			if(!lGpio) { config.getGpioConfig(gpio); lGpio = true; };
 			gpio.vccResistorGnd = String(buf+19).toInt();
@@ -2337,7 +2338,7 @@ void configFileParse() {
 				continue;
 			}
 
-			pc.value = getSplit(rest, 2).toFloat() * 10000;
+			pc.value = lround(getSplit(rest, 2).toDouble() * 10000.0);
 
 			String days = getSplit(rest, 3);
 			if(days.equals("all")) {

--- a/src/AmsWebServer.cpp
+++ b/src/AmsWebServer.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "AmsWebServer.h"
+#include <math.h>
 #include "CustomDefaults.h"
 #include "AmsWebHeaders.h"
 #include "FirmwareVersion.h"
@@ -1386,10 +1387,10 @@ void AmsWebServer::handleSave() {
 			memset(meterConfig.authenticationKey, 0, 16);
 		}
 
-		meterConfig.wattageMultiplier = server.arg(F("mmw")).toDouble() * 1000.0;
-		meterConfig.voltageMultiplier = server.arg(F("mmv")).toDouble() * 1000.0;
-		meterConfig.amperageMultiplier = server.arg(F("mma")).toDouble() * 1000.0;
-		meterConfig.accumulatedMultiplier = server.arg(F("mmc")).toDouble() * 1000.0;
+		meterConfig.wattageMultiplier = lround(server.arg(F("mmw")).toDouble() * 1000.0);
+		meterConfig.voltageMultiplier = lround(server.arg(F("mmv")).toDouble() * 1000.0);
+		meterConfig.amperageMultiplier = lround(server.arg(F("mma")).toDouble() * 1000.0);
+		meterConfig.accumulatedMultiplier = lround(server.arg(F("mmc")).toDouble() * 1000.0);
 		config->setMeterConfig(meterConfig);
 	}
 
@@ -1405,7 +1406,7 @@ void AmsWebServer::handleSave() {
 				if(!psk.equals("***")) {
 					strcpy(network.psk, psk.c_str());
 				}
-				network.power = server.arg(F("ww")).toDouble() * 10.0;
+				network.power = lround(server.arg(F("ww")).toDouble() * 10.0);
 				network.sleep = server.arg(F("wz")).toInt();
 				network.use11b = server.hasArg(F("wb")) && server.arg(F("wb")) == F("true");
 			}
@@ -1567,9 +1568,9 @@ void AmsWebServer::handleSave() {
 	}
 
 	if(server.hasArg(F("iv")) && server.arg(F("iv")) == F("true")) {
-		gpioConfig->vccOffset = server.hasArg(F("ivo")) && !server.arg(F("ivo")).isEmpty() ? server.arg(F("ivo")).toDouble() * 100.0 : 0;
-		gpioConfig->vccMultiplier = server.hasArg(F("ivm")) && !server.arg(F("ivm")).isEmpty() ? server.arg(F("ivm")).toDouble() * 1000.0 : 1000;
-		gpioConfig->vccBootLimit = server.hasArg(F("ivb")) && !server.arg(F("ivb")).isEmpty() ? server.arg(F("ivb")).toDouble() * 10.0 : 0;
+		gpioConfig->vccOffset = server.hasArg(F("ivo")) && !server.arg(F("ivo")).isEmpty() ? lround(server.arg(F("ivo")).toDouble() * 100.0) : 0;
+		gpioConfig->vccMultiplier = server.hasArg(F("ivm")) && !server.arg(F("ivm")).isEmpty() ? lround(server.arg(F("ivm")).toDouble() * 1000.0) : 1000;
+		gpioConfig->vccBootLimit = server.hasArg(F("ivb")) && !server.arg(F("ivb")).isEmpty() ? lround(server.arg(F("ivb")).toDouble() * 10.0) : 0;
 		config->setGpioConfig(*gpioConfig);
 	}
 
@@ -1684,7 +1685,7 @@ void AmsWebServer::handleSave() {
 				snprintf_P(buf, BUF_SIZE_COMMON, PSTR("rd%d"), i);
 				pc.direction = server.arg(buf).toInt();
 				snprintf_P(buf, BUF_SIZE_COMMON, PSTR("rv%d"), i);
-				pc.value = server.arg(buf).toDouble() * 10000.0;
+				pc.value = lround(server.arg(buf).toDouble() * 10000.0);
 				snprintf_P(buf, BUF_SIZE_COMMON, PSTR("rn%d"), i);
 				String name = server.arg(buf);
 				strcpy(pc.name, name.c_str());
@@ -2773,11 +2774,11 @@ void AmsWebServer::modifyDayPlot() {
 	for(uint8_t i = 0; i < 24; i++) {
 		snprintf_P(buf, BUF_SIZE_COMMON, PSTR("i%02d"), i);
 		if(server.hasArg(buf)) {
-			ds->setHourImport(i, server.arg(buf).toDouble() * 1000);
+			ds->setHourImport(i, lround(server.arg(buf).toDouble() * 1000.0));
 		}
 		snprintf_P(buf, BUF_SIZE_COMMON, PSTR("e%02d"), i);
 		if(server.hasArg(buf)) {
-			ds->setHourExport(i, server.arg(buf).toDouble() * 1000);
+			ds->setHourExport(i, lround(server.arg(buf).toDouble() * 1000.0));
 		}
 	}
 	bool ret = ds->save();
@@ -2798,11 +2799,11 @@ void AmsWebServer::modifyMonthPlot() {
 	for(uint8_t i = 1; i <= 31; i++) {
 		snprintf_P(buf, BUF_SIZE_COMMON, PSTR("i%02d"), i);
 		if(server.hasArg(buf)) {
-			ds->setDayImport(i, server.arg(buf).toDouble() * 1000);
+			ds->setDayImport(i, lround(server.arg(buf).toDouble() * 1000.0));
 		}
 		snprintf_P(buf, BUF_SIZE_COMMON, PSTR("e%02d"), i);
 		if(server.hasArg(buf)) {
-			ds->setDayExport(i, server.arg(buf).toDouble() * 1000);
+			ds->setDayExport(i, lround(server.arg(buf).toDouble() * 1000.0));
 		}
 	}
 	bool ret = ds->save();


### PR DESCRIPTION
Reported in #1251: a price modifier of `0.0464` is stored as `0.0463`, while `0.0463` and `0.0465` are kept.

## Cause

User-entered decimals are stored as scaled integers, and the cast to integer **truncates**:

```
atof("0.0464")            = 0.046399999999999996…
        × 10000.0         = 463.99999999999994
(uint32_t)                = 463
```

This is not a float-vs-double problem. Sweeping all 999999 four-decimal values through the price modifier conversion:

| conversion | stored one unit too low |
|---|---|
| `toFloat() * 10000` (≤ v2.5.5) | 68886 |
| `toDouble() * 10000.0` (v2.5.6 → main) | 68866 |
| `lround(toDouble() * 10000.0)` | **0** |

a7333653 (#1133) barely moved the count — it only changed *which* values land just below the integer. `0.0464` happened to be correct with `float` and moved into the broken set in v2.5.6, which is why this surfaces now on v2.5.7.

## Change

`lround()` at every scaling site rather than relying on the cast:

- **`AmsWebServer::handleSave()`** — price modifier value, meter wattage/voltage/amperage/accumulated multipliers, Wi-Fi power, Vcc offset/multiplier/boot limit
- **`AmsWebServer::modifyDayPlot()` / `modifyMonthPlot()`** — the day/month data editor
- **`configFileParse()`** — the same fields on config-file restore. This path also still used `toFloat()` for the Vcc values and the price modifier, so a backup/restore re-applied the old truncation; those are now `toDouble()` too.

`lround()` rounds half away from zero, which is correct for the one signed field here (`vccOffset`).

## Verification

- `0.0464` → `464`; the full 999999-value sweep is exact for all of them.
- `pio run -e esp32` and `pio run -e esp8266` both build. ESP8266 grows 208 bytes and stays at 98.0% flash (20973 bytes free).

🤖 Generated with [Claude Code](https://claude.com/claude-code)