### PR TITLE
Publish fixed prices independently of the dynamic price service

### DIFF
--- a/src/AmsToMqttBridge.cpp
+++ b/src/AmsToMqttBridge.cpp
@@ -1069,7 +1069,7 @@ void handleCustomMqtt() {
 			debugE_P(PSTR("Custom MQTT connector reporting error (%d)"), err);
 		customMqttHandler->connect();
 		customMqttHandler->publishSystem(&hw, ps, &ea);
-		if(ps != NULL && ps->hasPrice()) {
+		if(ps != NULL && ps->hasAnyPrice()) {
 			customMqttHandler->publishPrices(ps);
 		}
 	}
@@ -1451,7 +1451,7 @@ void handlePriceService(unsigned long now) {
 		
 		if(config.isPriceServiceChanged()) {
 			PriceServiceConfig price;
-			if(config.getPriceServiceConfig(price) && price.enabled && strlen(price.area) > 0) {
+			if(config.getPriceServiceConfig(price)) {
 				if(ps == NULL) {
 					ps = new PriceService(&Debug);
 					ea.setPriceService(ps);
@@ -1462,11 +1462,13 @@ void handlePriceService(unsigned long now) {
 					}
 					#endif
 				}
+				// Kept alive even when fetching is disabled, as it also holds the fixed prices
 				ps->setup(price);
 			} else if(ps != NULL) {
 				delete ps;
 				ps = NULL;
 				ws.setPriceService(NULL);
+				ea.setPriceService(NULL);
 			}
 			ws.setPriceSettings(price.area, price.currency);
 			config.ackPriceServiceChange();
@@ -1983,7 +1985,7 @@ void MQTT_connect() {
 		mqttHandler->setDataStorage(&ds);
 		mqttHandler->connect();
 		mqttHandler->publishSystem(&hw, ps, &ea);
-		if(ps != NULL && ps->hasPrice()) {
+		if(ps != NULL && ps->hasAnyPrice()) {
 			mqttHandler->publishPrices(ps);
 		}
 	}

--- a/src/PriceService.cpp
+++ b/src/PriceService.cpp
@@ -73,6 +73,7 @@ void PriceService::setup(PriceServiceConfig& config) {
     #endif
 
     load();
+    dynamicPriceNeedKnown = false;
 }
 
 void PriceService::setTimezone(Timezone* tz) {
@@ -123,6 +124,47 @@ bool PriceService::hasFixedPrice() {
         if(priceConfig.at(i).type == PRICE_TYPE_FIXED) {
             return true;
         }
+    }
+    return false;
+}
+
+bool PriceService::isDynamicPriceNeeded() {
+    if(!dynamicPriceNeedKnown) {
+        dynamicPriceNeeded = calculateDynamicPriceNeed();
+        dynamicPriceNeedKnown = true;
+        #if defined(AMS_REMOTE_DEBUG)
+        if (debugger->isActive(RemoteDebug::INFO))
+        #endif
+        debugger->printf_P(PSTR("(PriceService) Dynamic price is %sneeded\n"), dynamicPriceNeeded ? "" : "not ");
+    }
+    return dynamicPriceNeeded;
+}
+
+bool PriceService::calculateDynamicPriceNeed() {
+    if(!hasFixedPrice()) return true;
+
+    time_t ts = time(nullptr);
+    tmElements_t tm;
+    breakTime(entsoeTz->toLocal(ts), tm);
+    tm.Hour = tm.Minute = tm.Second = 0;
+    time_t startOfDay = entsoeTz->toUTC(makeTime(tm));
+
+    // Fixed price periods have hour granularity, and we can be asked for any hour of
+    // today and tomorrow, so those 48 hours are the whole horizon. Anchored at the start
+    // of today rather than at the current point, as the day cost is calculated backwards
+    // from midnight.
+    for(uint8_t hour = 0; hour < 48; hour++) {
+        breakTime(tz->toLocal(startOfDay + (hour * SECS_PER_HOUR)), tm);
+        tm.Minute = tm.Second = 0;
+
+        uint8_t covered = 0;
+        for(uint8_t i = 0; i < priceConfig.size(); i++) {
+            PriceConfig pc = priceConfig.at(i);
+            if(pc.type != PRICE_TYPE_FIXED) continue;
+            if(!timeIsInPeriod(tm, pc)) continue;
+            covered |= pc.direction;
+        }
+        if((covered & PRICE_DIRECTION_BOTH) != PRICE_DIRECTION_BOTH) return true;
     }
     return false;
 }
@@ -258,7 +300,7 @@ float PriceService::getPriceForRelativeHour(uint8_t direction, int8_t hour) {
     return valueSum / valueCount;
 }
 
-float PriceService::getFixedPrice(uint8_t direction, int8_t point) {
+float PriceService::getFixedPrice(uint8_t direction, uint8_t point) {
     time_t ts = time(nullptr);
 
     tmElements_t tm;
@@ -302,6 +344,7 @@ bool PriceService::loop() {
         #endif
         debugger->printf_P(PSTR("(PriceService) Day init\n"));
         currentDay = tm.Day;
+        dynamicPriceNeedKnown = false;
         currentPricePoint = getCurrentPricePointIndex();
         return hasFixedPrice(); // Publish a fixed price right away, we have nothing to wait for
     }
@@ -317,6 +360,7 @@ bool PriceService::loop() {
             tomorrow = NULL;
         }
         currentDay = tm.Day;
+        dynamicPriceNeedKnown = false;
         currentPricePoint = getCurrentPricePointIndex();
         return today != NULL || hasFixedPrice(); // Only trigger MQTT publish if we have todays prices, or a fixed price to fall back on.
     } else if(currentPricePoint != getCurrentPricePointIndex()) {
@@ -330,6 +374,19 @@ bool PriceService::loop() {
 
     if(!config->enabled)
         return false;
+
+    // A fixed price covering every hour in both directions makes the dynamic price
+    // irrelevant, so do not spend requests on fetching it
+    if(!isDynamicPriceNeeded()) {
+        if(today != NULL || tomorrow != NULL) {
+            if(today != NULL) delete today;
+            if(tomorrow != NULL) delete tomorrow;
+            today = tomorrow = NULL;
+            lastTodayFetch = lastTomorrowFetch = 0;
+        }
+        lastError = 0;
+        return false;
+    }
 
     #ifndef AMS2MQTT_PRICE_KEY
     if(strlen(getToken()) == 0) {
@@ -671,6 +728,7 @@ std::vector<PriceConfig>& PriceService::getPriceConfig() {
 }
 
 void PriceService::setPriceConfig(uint8_t index, PriceConfig &priceConfig) {
+    dynamicPriceNeedKnown = false;
     stripNonAscii((uint8_t*) priceConfig.name, 32, true);
 
     if(this->priceConfig.capacity() != index+1)
@@ -682,6 +740,7 @@ void PriceService::setPriceConfig(uint8_t index, PriceConfig &priceConfig) {
 }
 
 void PriceService::cropPriceConfig(uint8_t size) {
+    dynamicPriceNeedKnown = false;
     this->priceConfig.resize(size);
     this->priceConfig.shrink_to_fit();
 

--- a/src/PriceService.cpp
+++ b/src/PriceService.cpp
@@ -102,7 +102,7 @@ char* PriceService::getSource() {
         return this->today->getSource();
     } else if(tomorrow != NULL) {
         return this->tomorrow->getSource();
-    } else if(!this->config->enabled && this->priceConfig.capacity() != 0) {
+    } else if(hasFixedPrice()) {
         return "FIX"; // Fixed price
     }
     return "";
@@ -116,6 +116,27 @@ uint8_t PriceService::getNumberOfPointsAvailable() {
     if(today == NULL) return getResolutionInMinutes() == 15 ? 192 : 48;
     if(tomorrow != NULL) return today->getNumberOfPoints() + tomorrow->getNumberOfPoints();
     return today->getNumberOfPoints();
+}
+
+bool PriceService::hasFixedPrice() {
+    for (uint8_t i = 0; i < priceConfig.size(); i++) {
+        if(priceConfig.at(i).type == PRICE_TYPE_FIXED) {
+            return true;
+        }
+    }
+    return false;
+}
+
+int16_t PriceService::getLastKnownPricePoint(uint8_t direction) {
+    // Searching backwards, as the common case is that we know the price all the way
+    // to the end of the horizon and can return on the first probe.
+    uint8_t currentPricePointIndex = getCurrentPricePointIndex();
+    for(int16_t point = getNumberOfPointsAvailable() - 1; point >= currentPricePointIndex; point--) {
+        if(getPricePoint(direction, point) != PRICE_NO_VALUE) {
+            return point;
+        }
+    }
+    return -1;
 }
 
 bool PriceService::isExportPricesDifferentFromImport() {
@@ -282,6 +303,7 @@ bool PriceService::loop() {
         debugger->printf_P(PSTR("(PriceService) Day init\n"));
         currentDay = tm.Day;
         currentPricePoint = getCurrentPricePointIndex();
+        return hasFixedPrice(); // Publish a fixed price right away, we have nothing to wait for
     }
     
     if(currentDay != tm.Day) {
@@ -296,14 +318,14 @@ bool PriceService::loop() {
         }
         currentDay = tm.Day;
         currentPricePoint = getCurrentPricePointIndex();
-        return today != NULL || (!config->enabled && priceConfig.capacity() != 0); // Only trigger MQTT publish if we have todays prices.
+        return today != NULL || hasFixedPrice(); // Only trigger MQTT publish if we have todays prices, or a fixed price to fall back on.
     } else if(currentPricePoint != getCurrentPricePointIndex()) {
         #if defined(AMS_REMOTE_DEBUG)
         if (debugger->isActive(RemoteDebug::INFO))
         #endif
         debugger->printf_P(PSTR("(PriceService) Price point reset\n"));
         currentPricePoint = getCurrentPricePointIndex();
-        return today != NULL || (!config->enabled && priceConfig.capacity() != 0); // Only trigger MQTT publish if we have todays prices.
+        return today != NULL || hasFixedPrice(); // Only trigger MQTT publish if we have todays prices, or a fixed price to fall back on.
     }
 
     if(!config->enabled)
@@ -335,7 +357,7 @@ bool PriceService::loop() {
             today = NULL;
         }
         currentPricePoint = getCurrentPricePointIndex();
-        return today != NULL && !readyToFetchForTomorrow; // Only trigger MQTT publish if we have todays prices and we are not immediately ready to fetch price for tomorrow.
+        return today != NULL; // Publish as soon as we have todays prices. Tomorrows fetch publishes again if it succeeds.
     }
 
     // Prices for next day are published at 13:00 CE(S)T, but to avoid heavy server traffic at that time, we will 

--- a/src/PriceService.h
+++ b/src/PriceService.h
@@ -87,6 +87,9 @@ public:
     bool hasPrice() { return hasPrice(PRICE_DIRECTION_IMPORT); }
     bool hasPrice(uint8_t direction) { return getCurrentPrice(direction) != PRICE_NO_VALUE; }
     bool hasPricePoint(uint8_t direction, int8_t point) { return getPricePoint(direction, point) != PRICE_NO_VALUE; }
+    bool hasAnyPrice() { return getLastKnownPricePoint(PRICE_DIRECTION_IMPORT) > -1 || getLastKnownPricePoint(PRICE_DIRECTION_EXPORT) > -1; }
+    bool hasFixedPrice();
+    int16_t getLastKnownPricePoint(uint8_t direction); // Last point from the current one onwards that we know a price for, -1 if none
     
     float getCurrentPrice(uint8_t direction);
     float getPricePoint(uint8_t direction, uint8_t point);

--- a/src/PriceService.h
+++ b/src/PriceService.h
@@ -89,6 +89,7 @@ public:
     bool hasPricePoint(uint8_t direction, int8_t point) { return getPricePoint(direction, point) != PRICE_NO_VALUE; }
     bool hasAnyPrice() { return getLastKnownPricePoint(PRICE_DIRECTION_IMPORT) > -1 || getLastKnownPricePoint(PRICE_DIRECTION_EXPORT) > -1; }
     bool hasFixedPrice();
+    bool isDynamicPriceNeeded(); // False when a fixed price covers the whole horizon, making the dynamic price irrelevant
     int16_t getLastKnownPricePoint(uint8_t direction); // Last point from the current one onwards that we know a price for, -1 if none
     
     float getCurrentPrice(uint8_t direction);
@@ -135,11 +136,15 @@ private:
 
     int16_t lastError = 0;
 
+    bool dynamicPriceNeeded = true;
+    bool dynamicPriceNeedKnown = false;
+    bool calculateDynamicPriceNeed();
+
     PricesContainer* fetchPrices(time_t);
     bool retrieve(const char* url, Stream* doc);
     float getCurrencyMultiplier(const char* from, const char* to, time_t t);
     bool timeIsInPeriod(tmElements_t tm, PriceConfig pc);
-    float getFixedPrice(uint8_t direction, int8_t point);
+    float getFixedPrice(uint8_t direction, uint8_t point);
     float getEnergyPricePoint(uint8_t direction, uint8_t point);
 };
 #endif

--- a/src/mqtt/HomeAssistantMqttHandler.cpp
+++ b/src/mqtt/HomeAssistantMqttHandler.cpp
@@ -331,7 +331,7 @@ bool HomeAssistantMqttHandler::publishTemperatures(AmsConfiguration* config, HwT
 bool HomeAssistantMqttHandler::publishPrices(PriceService* ps) {
 	if(pubTopic[0] == '\0' || !connected())
 		return false;
-	if(!ps->hasPrice())
+	if(!ps->hasAnyPrice())
 		return false;
 
     publishPriceSensors(ps);
@@ -347,7 +347,7 @@ bool HomeAssistantMqttHandler::publishPrices(PriceService* ps) {
 		float val = ps->getPriceForRelativeHour(PRICE_DIRECTION_IMPORT, i);
 		values[i] = val;
 
-		if(val == PRICE_NO_VALUE) break;
+		if(val == PRICE_NO_VALUE) continue; // A hole, the price for this hour depends on a dynamic price we do not have
 		
 		if(val < min) min = val;
 		if(val > max) max = val;
@@ -700,13 +700,14 @@ void HomeAssistantMqttHandler::publishPriceSensors(PriceService* ps) {
     }
 
     uint8_t currentPricePointIndex = ps->getCurrentPricePointIndex();
-	uint8_t numberOfPoints = ps->getNumberOfPointsAvailable();
+    // Discover sensors all the way out to the last point we know a price for. Points in
+    // between can still be unknown, if they depend on a dynamic price we do not have.
+    int16_t lastImportPoint = ps->getLastKnownPricePoint(PRICE_DIRECTION_IMPORT);
+    int16_t lastExportPoint = ps->getLastKnownPricePoint(PRICE_DIRECTION_EXPORT);
 
-    if(priceImportInit < numberOfPoints-currentPricePointIndex) {
+    if(priceImportInit < lastImportPoint-currentPricePointIndex+1) {
         uint8_t importPriceSensorNo = 0;
-        for(int pricePointIndex = currentPricePointIndex; pricePointIndex < numberOfPoints; pricePointIndex++) {
-            float val = ps->getPricePoint(PRICE_DIRECTION_IMPORT, pricePointIndex);
-            if(val == PRICE_NO_VALUE) break;
+        for(int pricePointIndex = currentPricePointIndex; pricePointIndex <= lastImportPoint; pricePointIndex++) {
             if(importPriceSensorNo < priceImportInit) {
                 importPriceSensorNo++;
                 continue;
@@ -732,7 +733,7 @@ void HomeAssistantMqttHandler::publishPriceSensors(PriceService* ps) {
                 importPriceSensorNo == 0 ? "Current import price" : name,
                 "/prices",
                 path,
-                resolution * 60 + 300,
+                resolution * 60 * 2 + 300,
                 uom.c_str(),
                 "monetary",
                 importPriceSensorNo == 0 ? "total" : "",
@@ -744,11 +745,9 @@ void HomeAssistantMqttHandler::publishPriceSensors(PriceService* ps) {
         }
     }
 
-    if(priceExportInit < numberOfPoints-currentPricePointIndex) {
+    if(priceExportInit < lastExportPoint-currentPricePointIndex+1) {
         uint8_t exportPriceSensorNo = 0;
-        for(int pricePointIndex = currentPricePointIndex; pricePointIndex < numberOfPoints; pricePointIndex++) {
-            float val = ps->getPricePoint(PRICE_DIRECTION_EXPORT, pricePointIndex);
-            if(val == PRICE_NO_VALUE) break;
+        for(int pricePointIndex = currentPricePointIndex; pricePointIndex <= lastExportPoint; pricePointIndex++) {
             if(exportPriceSensorNo < priceExportInit) {
                 exportPriceSensorNo++;
                 continue;
@@ -774,7 +773,7 @@ void HomeAssistantMqttHandler::publishPriceSensors(PriceService* ps) {
                 exportPriceSensorNo == 0 ? "Current export price" : name,
                 "/prices",
                 path,
-                resolution * 60 + 300,
+                resolution * 60 * 2 + 300,
                 uom.c_str(),
                 "monetary",
                 exportPriceSensorNo == 0 ? "total" : "",

--- a/src/mqtt/JsonMqttHandler.cpp
+++ b/src/mqtt/JsonMqttHandler.cpp
@@ -305,7 +305,7 @@ bool JsonMqttHandler::publishTemperatures(AmsConfiguration* config, HwTools* hw)
 bool JsonMqttHandler::publishPrices(PriceService* ps) {
 	if(strlen(mqttConfig.publishTopic) == 0 || !connected())
 		return false;
-	if(!ps->hasPrice())
+	if(!ps->hasAnyPrice())
 		return false;
 
 	time_t now = time(nullptr);
@@ -319,7 +319,7 @@ bool JsonMqttHandler::publishPrices(PriceService* ps) {
 		float val = ps->getPriceForRelativeHour(PRICE_DIRECTION_IMPORT, i);
 		values[i] = val;
 
-		if(val == PRICE_NO_VALUE) break;
+		if(val == PRICE_NO_VALUE) continue; // A hole, the price for this hour depends on a dynamic price we do not have
 		
 		if(val < min) min = val;
 		if(val > max) max = val;

--- a/src/mqtt/RawMqttHandler.cpp
+++ b/src/mqtt/RawMqttHandler.cpp
@@ -243,7 +243,7 @@ bool RawMqttHandler::publishTemperatures(AmsConfiguration* config, HwTools* hw) 
 bool RawMqttHandler::publishPrices(PriceService* ps) {
 	if(topic.isEmpty() || !connected())
 		return false;
-	if(!ps->hasPrice())
+	if(!ps->hasAnyPrice())
 		return false;
 
 	time_t now = time(nullptr);
@@ -258,7 +258,7 @@ bool RawMqttHandler::publishPrices(PriceService* ps) {
 		values[i] = val;
 
         if(i > 23) continue;
-		if(val == PRICE_NO_VALUE) break;
+		if(val == PRICE_NO_VALUE) continue; // A hole, the price for this hour depends on a dynamic price we do not have
 		
 		if(val < min) min = val;
 		if(val > max) max = val;


### PR DESCRIPTION
Fixes #1253. Also fixes the withheld-publish behaviour seen in #1252, and means the price entities in #1249 already carry fixed price + modifiers when the server is down.

In #1253 the reporter has a fixed price (Norgespris) plus modifiers, with *Enable price fetch from remote server* still ticked. While the price server was down nothing was published to MQTT, even though the web dashboard showed the right price. The price error itself never gated publishing — the publish *trigger* did, in several ways that all bite exactly when the price source is unavailable.

## What was wrong

**1. The fixed-price fallback only applied when fetching was disabled.** Both price-point triggers in `PriceService::loop()` returned

```cpp
return today != NULL || (!config->enabled && priceConfig.capacity() != 0);
```

With fetching *enabled* but not delivering (`today == NULL`), that is `false || (false && …)`. This is the reported bug: a fixed price plus modifiers and the fetch option ticked published nothing on the hour. Only the one-shot publish in `MQTT_connect()` got anything out, which is why a reboot did not help either — at that point `hasPrice()` was consulted before any fetch had happened. Both triggers now fall back on a new `hasFixedPrice()` regardless of `config->enabled`.

**2. Day init published nothing.** The `currentDay == 0` branch fell through without signalling a publish, so a fixed price was not published until the next price point — up to an hour after boot.

**3. Today's prices were withheld when tomorrow's were pending.**

```cpp
return today != NULL && !readyToFetchForTomorrow;
```

Rebooting after 13:00 while tomorrow is unavailable fetched today's prices successfully, showed them in the UI, and then withheld them from MQTT until the next price point — the #1252 symptom. The tomorrow fetch publishes again if it succeeds, so the extra condition only ever cost correctness.

**4. Partial fixed prices were dropped entirely.** The three handlers gated the whole payload on `ps->hasPrice()`, which only looks at the *current* price point. A fixed price configured for a period of the year or for certain hours of the day is unknown right now but known later, so nothing at all was published. They now gate on `hasAnyPrice()`, emit `null` for the points where a dynamic component is involved, and the min/max/cheapest-window scan skips holes instead of stopping at the first one. Home Assistant discovery had the same `break` and now spans holes out to the last point we know a price for, so those entities exist and read `unknown` until their slot arrives.

**5. Home Assistant price sensors had no expiry margin.** `expire_after = resolution * 60 + 300` is 3900 s against an hourly publish cadence. One missed publish — an MQTT drop across the hour boundary — took every price entity unavailable for the rest of the hour. They now get a full extra price point of slack.

**6. Disabling price fetching freed the fixed prices and left a dangling pointer.** `handlePriceService()` deleted the `PriceService` when `enabled == false`, but that object also holds the fixed prices loaded from LittleFS, so following the advice in #1253 to untick the option stopped the fixed price working until the next reboot. It also cleared the pointer in `AmsWebServer` but not in `EnergyAccounting`, whose `if(ps == NULL) return;` guard in `calcDayCost()` therefore did not protect it. The service is now kept alive and reconfigured through `setup()` (which already discards cached dynamic prices and reloads the fixed ones), mirroring what boot does; the teardown path nulls `EnergyAccounting`'s pointer too.

`getSource()` used the same `!config->enabled` condition and so reported no source instead of `FIX` when fetching was enabled but failing.

## Not fetching what cannot matter

Rather than asking users to untick the box, the firmware now works out whether the dynamic price can affect anything. `getPricePoint()` only falls back to the dynamic price where no fixed price applies, so if every hour of today and tomorrow is covered by a fixed price in both directions, fetching is pure cost — a request, an error state and a red banner for a value that is never used.

`isDynamicPriceNeeded()` walks those 48 hours and accumulates which directions a fixed price covers, so a split import/export configuration counts as covered just like a single `BOTH` entry. When nothing is needed, `loop()` skips the fetch, discards any cached containers and clears `lastError`. The horizon is anchored at the start of today rather than at the current price point, because `calcDayCost()` reaches backwards to midnight; that means it only moves at midnight, so the answer is cached and invalidated on day change and whenever the price configuration is touched. Full 24-hour coverage is also what makes this DST-safe: a config that covers every hour stays covered whichever way the clocks move, and a partial one needs fetching anyway.

A partial fixed price keeps fetching, and a period boundary entering the horizon starts fetching a day before it is needed.

This also answers the objection raised in #1253 that users would lose the signal that the price server is down. Where the dynamic price genuinely matters, its absence is still visible: those points publish as `null` and the corresponding Home Assistant entities read unknown. The signal is only suppressed where there is nothing to signal, because no price depends on the server.

## Also fixed

`getFixedPrice()` took an `int8_t point` while `getPricePoint()` passes points up to 191 for a 15-minute two-day horizon, so everything from 128 up truncated to a negative offset and a partial fixed price resolved against a time before today's midnight for the back half of tomorrow. Widened to `uint8_t`.

## Behaviour after this change

| Setup | Before | After |
|---|---|---|
| Fixed price + modifiers, fetching enabled, server down (#1253) | Nothing published | Hourly, plus at boot, and no fetch attempted |
| Fixed price, fetching disabled | Hourly, nothing at boot | Hourly, plus at boot |
| Fixed price for a period/hours, server down | Nothing published | Known slots published, `null` elsewhere, keeps fetching |
| Dynamic, today fetched, tomorrow 404 (#1252) | Withheld until next price point | Published immediately |
| Fetching disabled at runtime | Fixed price lost, dangling pointer | Keeps working |

## Verification

- `pio run` — all six targets in `default_envs` build (esp8266dev, esp32dev, esp32s2dev, esp32solodev, esp32c3dev, esp32s3dev).
- `pio test -e native` — 17/17 decoder tests pass.
- ESP8266 flash: 1026723 → 1027567 bytes (+844), 16897 bytes headroom remaining.
- No config struct layout change, so `EEPROM_CHECK_SUM` is untouched.

Worth a look on real hardware for the two transitions, which I could not exercise here: making a config fully fixed while dynamic prices are cached (containers are discarded, so the price point grid moves from 15 to 60 minutes and Home Assistant re-discovers), and a period boundary entering the horizon.

## Known limitation, not addressed here

`getResolutionInMinutes()` returns 60 whenever `today == NULL`, so a fixed price is published on an hourly grid even in a 15-minute area, and Home Assistant sensors discovered before the first successful fetch carry hour-based display names. Changing the fallback to `config->resolutionInMinutes` would fix the naming but would also discover 192 entities for a price that never changes, and would need a null guard added in `getPriceForRelativeHour()`, which dereferences `today` in its non-60 branch. Left alone; the values are unaffected, as `prices.import[n]` is always n price points from now.

Unrelated and left alone: `getCurrentPrice()` has an unused `ts` local that the compiler already warns about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
