### PR TITLE
Decode the COSEM clock without the process timezone

### DIFF
--- a/src/decoder/src/Cosem.cpp
+++ b/src/decoder/src/Cosem.cpp
@@ -8,20 +8,30 @@
 #include "byteorder.h"
 #include <time.h>
 
+// Days since 1970-01-01 for a proleptic Gregorian date (Howard Hinnant's
+// days_from_civil). Pure integer arithmetic: unlike mktime() it never consults
+// the process timezone.
+static int32_t daysFromCivil(int32_t y, uint32_t m, uint32_t d) {
+    y -= m <= 2;
+    const int32_t era = (y >= 0 ? y : y - 399) / 400;
+    const uint32_t yoe = (uint32_t) (y - era * 400);                     // [0, 399]
+    const uint32_t doy = (153 * (m + (m > 2 ? -3 : 9)) + 2) / 5 + d - 1; // [0, 365]
+    const uint32_t doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;          // [0, 146096]
+    return era * 146097 + (int32_t) doe - 719468;
+}
+
 time_t decodeCosemDateTime(CosemDateTime timestamp) {
     uint16_t year = ntohs(timestamp.year);
     if(year < 1970) return 0;
 
-    struct tm tm = {};
-    tm.tm_year  = year - 1900;        // tm_year is years since 1900
-    tm.tm_mon   = timestamp.month - 1; // tm_mon is 0-based
-    tm.tm_mday  = timestamp.dayOfMonth;
-    tm.tm_hour  = timestamp.hour;
-    tm.tm_min   = timestamp.minute;
-    tm.tm_sec   = timestamp.second;
-    tm.tm_isdst = 0;
+    // The broken-down fields are converted as if they were UTC. The offset is
+    // carried by the meter's own deviation, applied below. Converting with a
+    // timezone-aware call such as mktime() would apply the firmware's
+    // configured zone a second time, putting the clock one whole UTC offset in
+    // the past (-1h in CET, -2h in CEST).
+    time_t t = (time_t) daysFromCivil(year, timestamp.month, timestamp.dayOfMonth) * 86400
+             + timestamp.hour * 3600 + timestamp.minute * 60 + timestamp.second;
 
-    time_t t = mktime(&tm);
     int16_t deviation = ntohs(timestamp.deviation);
     if(deviation >= -720 && deviation <= 720) {
         t += deviation * 60;

--- a/test/test_decoder/test_main.cpp
+++ b/test/test_decoder/test_main.cpp
@@ -66,6 +66,7 @@ void test_iskra_am550_slovenia(void);
 void test_aidon_norway_list2(void);
 void test_kamstrup_norway(void);
 void test_kamstrup_timezone(void);
+void test_meter_clock_is_timezone_independent(void);
 void test_dsmr_accepts_lf_and_crlf(void);
 // defined in test_encrypted.cpp
 void test_encrypted_decode(void);
@@ -91,6 +92,7 @@ int main(int argc, char** argv) {
     RUN_TEST(test_aidon_norway_list2);
     RUN_TEST(test_kamstrup_norway);
     RUN_TEST(test_kamstrup_timezone);
+    RUN_TEST(test_meter_clock_is_timezone_independent);
     RUN_TEST(test_dsmr_accepts_lf_and_crlf);
     RUN_TEST(test_unencrypted_golden);
     RUN_TEST(test_encrypted_decode);

--- a/test/test_decoder/test_unencrypted.cpp
+++ b/test/test_decoder/test_unencrypted.cpp
@@ -204,3 +204,46 @@ void test_kamstrup_timezone(void) {
         delete d;
     }
 }
+
+// Decode the same fixture with a specific process timezone in effect.
+static time_t decode_meter_clock_under_tz(const char* path, const char* zone) {
+    setenv("TZ", zone, 1);
+    tzset();
+    AmsData* d = harness_decode_fixture(path);
+    time_t ts = (d != NULL) ? d->getMeterTimestamp() : 0;
+    delete d;
+    return ts;
+}
+
+void test_meter_clock_is_timezone_independent(void) {
+    // A COSEM date-time carries its own UTC deviation, so decoding it must not
+    // depend on the timezone the firmware happens to be configured for. The
+    // device sets TZ (Europe/Oslo etc.), and any use of a TZ-aware conversion
+    // such as mktime() applies that offset a second time on top of the
+    // deviation, putting the meter clock one whole UTC offset in the past
+    // (-2h observed on a live Aidon meter in CEST, -1h in CET).
+    //
+    // Note this is NOT covered by test_kamstrup_timezone: the Kamstrup branch
+    // of IEC6205675::adjustForKnownIssues discards decodeCosemDateTime()'s
+    // result and recomputes the epoch itself, so that test cannot reach this
+    // code path. These Aidon frames do reach it.
+    const char* zones[] = {"Europe/Oslo", "Pacific/Auckland", "America/Denver", "Asia/Kathmandu"};
+    const char* fixtures[] = {
+        "test/payloads/aidon/gh1119-1.hex",  // hourly frame, carries a meter clock
+        "test/payloads/aidon/gh1119-4.hex",
+    };
+
+    for (size_t f = 0; f < COUNT(fixtures); f++) {
+        time_t ref = decode_meter_clock_under_tz(fixtures[f], "UTC");
+        TEST_ASSERT_NOT_EQUAL_MESSAGE(0, ref, fixtures[f]);
+        for (size_t z = 0; z < COUNT(zones); z++) {
+            time_t got = decode_meter_clock_under_tz(fixtures[f], zones[z]);
+            printf("  %-32s %-17s got=%ld ref=%ld (%+ld s)\n",
+                   fixtures[f], zones[z], (long) got, (long) ref, (long) (got - ref));
+            TEST_ASSERT_EQUAL_MESSAGE(ref, got, zones[z]);
+        }
+    }
+
+    setenv("TZ", "UTC", 1);   // leave the process in a known zone for later tests
+    tzset();
+}


### PR DESCRIPTION
## What

`decodeCosemDateTime()` converts the meter's broken-down clock with `mktime()`, which interprets the fields as **local** time per the process timezone. The meter's own UTC `deviation` is then added on top, so the zone offset is applied **twice** and the meter clock lands one whole UTC offset in the past.

`v2.5.7` used `makeTime()` here (`lib/AmsDecoder/src/Cosem.cpp`) — pure calendar arithmetic, timezone-free. The regression arrived with c9fd6cee, when the decoder was made Arduino-free: `makeTime()` is an Arduino Time-library function and `mktime()` is the natural, but timezone-aware, substitute.

## How it was found

A v2.5.7 device and a current build were run side by side for ~16 hours against the same HAN port (same Aidon meter, both `Europe/Oslo`, both publishing to the same broker). Every other value matched — instantaneous power, all three phases, the hourly accumulated registers, peaks, `monthmax`, the whole price curve — but `<topic>/meter/clock` was **exactly 7200 s behind at sixteen consecutive hourly frames**:

| hourly frame | v2.5.7 (correct) | this build | delta |
|---|---|---|---|
| 13:00 CEST | 1788692400 | 1788685200 | −7200 |
| 14:00 CEST | 1788696000 | 1788688800 | −7200 |
| … | … | … | −7200 |
| 04:00 CEST | 1788746400 | 1788739200 | −7200 |

The error equals the zone's current UTC offset, so **−2h in CEST and −1h in CET** — it changes at the DST boundary. `meter/dlms/timestamp` is unaffected; it takes a different path.

## The fix

Convert with `days_from_civil` — integer arithmetic only, identical on device and native. No new include: `Cosem.cpp` deliberately depends on nothing but `Cosem.h`/`byteorder.h`/`time.h`, so pulling in the Timezone header just to reach `makeTime()` again was not an option.

Validated against `timegm()` over all **47847 dates from 1970-01-01 to 2100-12-31**, including every leap-year edge — no mismatch. Behaviour under `TZ=UTC` is unchanged, so the golden master does not move.

## Why no existing test caught this

`test_kamstrup_timezone` does assert a meter timestamp, but it cannot reach the bug:

1. The Kamstrup branch of `IEC6205675::adjustForKnownIssues` **discards** `decodeCosemDateTime()`'s result and recomputes the epoch itself with `makeTime()` (`IEC6205675.cpp:1428`), so the `mktime()` line never runs.
2. That test also builds its expectation with `makeTime()` (`utc_epoch()`), leaving both sides of the assertion timezone-free.

So no test asserted a clock on a path that *keeps* the `mktime()`-derived value — which is every non-Kamstrup meter: Aidon, and the generic `tz->toUTC()` fallback. Note the native `makeTime()` stub (`test/stubs/Timezone.h:20`) is implemented with `timegm()`, which is why simply running the suite under a non-UTC `TZ` does **not** expose it either.

`test_meter_clock_is_timezone_independent` decodes two Aidon hourly fixtures under `Europe/Oslo`, `Pacific/Auckland`, `America/Denver` and `Asia/Kathmandu` and asserts each matches the UTC decode. Asserting the *invariant* rather than a hand-derived epoch keeps it honest regardless of which zones the CI host has.

## Verification

- `pio test -e native` — 18/18 pass (17 before + the new one)
- New test **fails** on the old implementation (`Expected 1765724400 Was 1765720800`, −3600 for these December frames) and **passes** on the new one
- Full suite also passes under `TZ=Europe/Oslo`
- `pio run -e esp32s2` builds clean
- `test_unencrypted_golden` unchanged — no fixture decodes differently

## Scope

Fix only. Three other things surfaced during the comparison and are deliberately **not** here: the `services` 60 s republish is intentional (explicit heartbeat guard), the broker holding no retained messages is broker-side and affects both devices equally, and a ~1 NOK step in the persisted day/month **cost** accumulators across a reboot was not reproducible from passive observation — every live cost increment matched to the cent, and the standing offsets cleared the moment their accumulator reset at midnight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)