### PR TITLE
Fix use-after-free when temperature sensors are re-initialised after a config save

### DIFF
--- a/src/HwTools.cpp
+++ b/src/HwTools.cpp
@@ -302,23 +302,29 @@ bool HwTools::updateTemperatures() {
             DeviceAddress addr;
             sensorApi->requestTemperatures();
             int c = sensorApi->getDeviceCount();
-            if(this->tempSensors != NULL) {
-                delete this->tempSensors;
-            }
-            this->tempSensors = new TempSensorData*[c];
+            // setup() clears tempSensorInit after every configuration save, so
+            // this block runs again with sensorCount > 0. Keep the old array
+            // alive while matching addresses, then release what is left.
+            TempSensorData** oldSensors = this->tempSensors;
+            uint8_t oldCount = sensorCount;
+            this->tempSensors = new TempSensorData*[c > 0 ? c : 1];
+            sensorCount = 0;
             for(int i = 0; i < c; i++) {
                 bool found = false;
                 sensorApi->getAddress(addr, i);
                 float t = sensorApi->getTempC(addr);
-                for(int x = 0; x < sensorCount; x++) {
-                    TempSensorData *data = tempSensors[x];
-                    if(isSensorAddressEqual(data->address, addr)) {
+                for(int x = 0; x < oldCount; x++) {
+                    TempSensorData *data = oldSensors[x];
+                    if(data != NULL && isSensorAddressEqual(data->address, addr)) {
                         found = true;
                         data->lastRead = t;
                         if(t > -85) {
                             data->changed = data->lastValidRead != t;
                             data->lastValidRead = t;
                         }
+                        tempSensors[sensorCount++] = data;
+                        oldSensors[x] = NULL;
+                        break;
                     }
                 }
                 if(!found) {
@@ -332,6 +338,12 @@ bool HwTools::updateTemperatures() {
                     tempSensors[sensorCount++] = data;
                 }
                 yield();
+            }
+            if(oldSensors != NULL) {
+                for(int x = 0; x < oldCount; x++) {
+                    if(oldSensors[x] != NULL) delete oldSensors[x];
+                }
+                delete[] oldSensors;
             }
         } else {
             if(sensorCount > 0) {


### PR DESCRIPTION
## Problem
`HwTools::setup()` runs after every web UI save that does not require a restart (see `AmsWebServer::handleSave`), and it clears `tempSensorInit`. The next `updateTemperatures()` therefore enters the init branch again while `sensorCount` is still set from the previous run. That branch deleted the `tempSensors` array and then searched it for matching addresses, dereferencing freed memory.

On ESP8266 this reproduces as an exception 28 (LoadProhibited) in `isSensorAddressEqual()` on the first temperature read after saving, for example after changing MQTT settings on a device with a DS18B20 attached. Stack from the crash:

```
epc1=0x4024f972 excvaddr=0x000006c7
HwTools::isSensorAddressEqual -> handleTemperature -> loop
```

## Fix
Keep the old array alive while matching addresses, move surviving entries into the new array, free entries for sensors that are gone, and use `delete[]` for the array.

## Tested
ESP8266 (D1 mini), one DS18B20 on GPIO14, v2.5.7 and current main. Saving MQTT settings crashed the device every time before; after the fix the save completes and the sensor keeps reporting.