### PR TITLE
Size the SoftwareSerial ISR edge buffer independently of the byte buffer

### DIFF
--- a/src/PassiveMeterCommunicator.cpp
+++ b/src/PassiveMeterCommunicator.cpp
@@ -6,6 +6,15 @@
 
 #include "PassiveMeterCommunicator.h"
 
+// Multiplier for the SoftwareSerial ISR edge buffer relative to the byte
+// buffer. 4 gives ~0.4 s of slack at 2400 baud 8E1 for 4 x 64 x 4 B = 1 kB
+// extra heap with the default 64 byte buffer. The library's own default is
+// (2 + data bits + parity), i.e. 11 for 8E1, but that costs 11 kB with a
+// 256 byte buffer, too much on ESP8266. Override with -D SWSERIAL_ISR_BUFFER_FACTOR=n.
+#ifndef SWSERIAL_ISR_BUFFER_FACTOR
+#define SWSERIAL_ISR_BUFFER_FACTOR 4
+#endif
+
 const uint32_t AUTO_BAUD_RATES[] = { 2400, 9600, 115200 };
 const uint8_t AUTO_BAUD_RATES_COUNT = sizeof(AUTO_BAUD_RATES) / sizeof(AUTO_BAUD_RATES[0]);
 #include "IEC6205675.h"
@@ -779,7 +788,12 @@ void PassiveMeterCommunicator::setupHanPort(uint32_t baud, uint8_t parityOrdinal
 			if (debugger->isActive(RemoteDebug::DEBUG))
 			#endif
 			debugger->printf_P(PSTR("Using serial buffer size %d\n"), 64 * bufferSize);
-			swSerial->begin(baud, serialConfig, rxpin, txpin, invert, meterConfig.bufferSize * 64, meterConfig.bufferSize * 64);
+			// The second capacity is the ISR edge buffer: one entry per bit
+			// transition, so up to (2 + data bits + parity) entries per byte.
+			// Sizing it equal to the byte buffer leaves room for only ~25 bytes
+			// of pending data at 8E1, which overflows as soon as loop() is held
+			// up for ~0.1 s at 2400 baud (web requests, MQTT publish, LittleFS).
+			swSerial->begin(baud, serialConfig, rxpin, txpin, invert, meterConfig.bufferSize * 64, meterConfig.bufferSize * 64 * SWSERIAL_ISR_BUFFER_FACTOR);
 			hanSerial = swSerial;
 			hwSerial = NULL;
 		#else


### PR DESCRIPTION
## Problem
EspSoftwareSerial keeps two receive buffers: the byte buffer and an ISR buffer with one 32-bit entry per bit transition. `PassiveMeterCommunicator` passes the same capacity for both. A byte at 8E1 produces up to 11 transitions, so a 256 entry ISR buffer holds roughly 25 bytes, about 0.1 s of data at 2400 baud. Any `loop()` stall longer than that (serving the web UI, an MQTT publish burst, a LittleFS write) overflows the ISR buffer and the reader reports "Serial buffer full" although the byte buffer is almost empty. The library's own documentation suggests `bufCapacity * (2 + data bits + parity)`.

## Fix
Scale the ISR buffer by `SWSERIAL_ISR_BUFFER_FACTOR` (default 4: about 0.4 s of slack, 1 kB extra with the default 64 byte buffer). The library default of 11 would be exact but costs 11 kB with a 256 byte buffer, which ESP8266 cannot afford. The factor can be overridden with `-D SWSERIAL_ISR_BUFFER_FACTOR=n`.

## Tested
ESP8266 reading an Aidon 6525 (2400 baud 8E1) on GPIO5 via software serial over a weak WiFi link. Before: loading the web UI reliably produced "Serial buffer overflow" in the debug log. With the factor raised, the same test produced none.