### PR TITLE
Read DS18B20 temperatures without blocking loop()

### DIFF
--- a/src/HwTools.cpp
+++ b/src/HwTools.cpp
@@ -335,7 +335,20 @@ bool HwTools::updateTemperatures() {
             }
         } else {
             if(sensorCount > 0) {
-                sensorApi->requestTemperatures();
+                // A DS18B20 conversion takes up to 750 ms at 12 bit resolution.
+                // Waiting for it inline stalls loop() (and the HAN reader) once
+                // every 15 s, so request the conversion now and collect the
+                // result on a later call.
+                if(tempRequestedAt == 0) {
+                    sensorApi->setWaitForConversion(false);
+                    sensorApi->requestTemperatures();
+                    tempRequestedAt = millis();
+                    return false;
+                }
+                if(millis() - tempRequestedAt < 800) {
+                    return false;
+                }
+                tempRequestedAt = 0;
 
                 for(int x = 0; x < sensorCount; x++) {
                     TempSensorData *data = tempSensors[x];

--- a/src/HwTools.h
+++ b/src/HwTools.h
@@ -69,6 +69,7 @@ private:
 
     uint16_t analogRange = 1024;
     bool tempSensorInit;
+    unsigned long tempRequestedAt = 0;
     OneWire *oneWire = NULL;
     DallasTemperature *sensorApi = NULL;
     uint8_t sensorCount = 0;


### PR DESCRIPTION
## Problem
`updateTemperatures()` called `requestTemperatures()` with the library default wait-for-conversion, which blocks for the full conversion time (up to 750 ms at 12 bit). The main loop logs this as `Used 1323ms to update temperature` every 15 s. On ESP8266 with a software serial HAN port that pause is long enough to overflow the receive buffer.

## Fix
Start the conversion asynchronously (`setWaitForConversion(false)`), return `false` until 800 ms have passed, then read the values. `handleTemperature()` already retries on `false`, so the publish cadence is unchanged; the wait just happens in the background. The first-time init path is left as is.

## Tested
ESP8266 with one DS18B20. The 1.3 s warning is gone from the debug log and the reported temperature is unchanged.