### PR TITLE
Return the configured payload format from MQTT handlers

### DIFF
--- a/src/mqtt/AmsMqttHandler.cpp
+++ b/src/mqtt/AmsMqttHandler.cpp
@@ -201,8 +201,15 @@ bool AmsMqttHandler::loop() {
     bool ret = connected() && mqtt.loop();
 	if(ret) {
 		lastSuccessfulLoop = now;
+		hadSuccessfulLoop = true;
 	} else if(mqttConfig.rebootMinutes > 0) {
-		if(now - lastSuccessfulLoop > (uint64_t) mqttConfig.rebootMinutes * 60000) {
+		// Until the first successful loop there is nothing to measure from;
+		// start the grace period now instead of treating boot as the last
+		// success, which would reboot immediately once uptime passes the limit.
+		if(!hadSuccessfulLoop) {
+			lastSuccessfulLoop = now;
+			hadSuccessfulLoop = true;
+		} else if(now - lastSuccessfulLoop > (uint64_t) mqttConfig.rebootMinutes * 60000) {
 			// Reboot the device if the MQTT connection is lost for too long
 			#if defined(AMS_REMOTE_DEBUG)
 			if (debugger->isActive(RemoteDebug::WARNING))

--- a/src/mqtt/AmsMqttHandler.h
+++ b/src/mqtt/AmsMqttHandler.h
@@ -100,6 +100,7 @@ protected:
     char* json;
     uint64_t lastStateUpdate = 0;
     uint64_t lastSuccessfulLoop = 0;
+    bool hadSuccessfulLoop = false;
 
     char pubTopic[64];
     char subTopic[64];

--- a/src/mqtt/JsonMqttHandler.cpp
+++ b/src/mqtt/JsonMqttHandler.cpp
@@ -486,7 +486,8 @@ bool JsonMqttHandler::publishSystem(HwTools* hw, PriceService* ps, EnergyAccount
 }
 
 uint8_t JsonMqttHandler::getFormat() {
-    return 0;
+    // This handler serves formats 0, 5 and 6; report the configured one
+    return format;
 }
 
 bool JsonMqttHandler::publishRaw(uint8_t* raw, size_t length) {

--- a/src/mqtt/JsonMqttHandler.h
+++ b/src/mqtt/JsonMqttHandler.h
@@ -19,6 +19,7 @@ public:
     #endif
         this->hw = hw;
         this->ds = ds;
+        this->format = mqttConfig.payloadFormat;
     };
     #if defined(AMS_REMOTE_DEBUG)
     JsonMqttHandler(MqttConfig& mqttConfig, RemoteDebug* debugger, char* buf, HwTools* hw, AmsDataStorage* ds, AmsFirmwareUpdater* updater) : AmsMqttHandler(mqttConfig, debugger, buf, updater) {
@@ -27,6 +28,7 @@ public:
     #endif
         this->hw = hw;
         this->ds = ds;
+        this->format = mqttConfig.payloadFormat;
     };
     bool publish(AmsData* data, AmsData* previousState, EnergyAccounting* ea, PriceService* ps);
     bool publishTemperatures(AmsConfiguration*, HwTools*);
@@ -40,6 +42,7 @@ public:
     uint8_t getFormat();
 
 private:
+    uint8_t format = 0;
     HwTools* hw;
     bool hasExport = false;
     // ds is inherited from AmsMqttHandler (shared with dayplot/monthplot commands)

--- a/src/mqtt/RawMqttHandler.cpp
+++ b/src/mqtt/RawMqttHandler.cpp
@@ -397,7 +397,8 @@ bool RawMqttHandler::publishSystem(HwTools* hw, PriceService* ps, EnergyAccounti
 }
 
 uint8_t RawMqttHandler::getFormat() {
-    return full ? 3 : 2;
+    // Raw payload formats are 1 (minimal) and 2 (full)
+    return full ? 2 : 1;
 }
 
 bool RawMqttHandler::publishRaw(uint8_t* raw, size_t length) {


### PR DESCRIPTION
## Problem
`MQTT_connect()` compares `mqttHandler->getFormat()` against `mqttConfig.payloadFormat` and replaces the handler when they differ, but two handlers never report the configured value:

| Handler | Returns | Serves formats |
|---|---|---|
| `RawMqttHandler::getFormat()` | `full ? 3 : 2` | 1 (minimal), 2 (full) |
| `JsonMqttHandler::getFormat()` | `0` | 0, 5, 6 |

So for payload formats 1, 2, 5 and 6 the comparison never matches and the handler is deleted and reconstructed on every reconnect.

Besides the heap churn, this breaks the reboot-on-MQTT-loss feature. A fresh handler has `lastSuccessfulLoop = 0`, which `AmsMqttHandler::loop()` reads as "last success at boot". Once uptime exceeds `rebootMinutes`, the first failed connection reboots the device immediately instead of after the configured grace period.

Reproduced on an ESP8266 with raw minimal payload and `rebootMinutes = 10`: after 16 hours of uptime, a single `Failed to connect to MQTT: -9` rebooted the device five seconds later with `REBOOT_CAUSE_MQTT_DISCONNECTED`. Two more unexplained reboots the night before matched the same pattern.

## Fix
Report the configured format from both handlers: raw returns 1 or 2, json returns the format stored at construction. Domoticz (3), Home Assistant (4) and Passthrough (255) already reported their configured value.

Also start the reboot grace period at the first failed loop when no successful loop has happened yet, so a handler that has never connected cannot trip the timer on its first attempt.

Note on the shape of the fix: dropping the two overrides entirely and letting the base class return a stored format is tidier, but it moves each class's key function, so the vtable and its inline virtuals get emitted in every translation unit. That cost 25 616 bytes of flash and pushed the esp8266 target over its partition. Keeping the out-of-line definitions costs 48 bytes.

## Tested
ESP8266, raw minimal payload, `rebootMinutes = 10`. Before: reboot within seconds of any MQTT connect failure. After: the connection is retried and the handler survives; flash 1 024 431 -> 1 024 479 bytes on `env:esp8266`.